### PR TITLE
Implement Chapter 1 rasterizer functionality

### DIFF
--- a/src1/render/shader.cpp
+++ b/src1/render/shader.cpp
@@ -1,5 +1,7 @@
 #include "rasterizer_renderer.h"
 #include "../utils/math.hpp"
+#include <algorithm>
+#include <cmath>
 #include <cstdio>
 
 #ifdef _WIN32
@@ -16,10 +18,25 @@ VertexShaderPayload vertex_shader(const VertexShaderPayload& payload)
     VertexShaderPayload output_payload = payload;
 
     // Vertex position transformation
+    Eigen::Matrix4f model = Uniforms::inv_trans_M.inverse().transpose();
+    Eigen::Vector4f model_position = payload.world_position;
+    Eigen::Vector4f world_position  = model * model_position;
+    Eigen::Vector4f clip_position   = Uniforms::MVP * model_position;
+
+    Eigen::Vector3f ndc = clip_position.head<3>() / clip_position.w();
+    float           x   = 0.5f * (ndc.x() + 1.0f) * static_cast<float>(Uniforms::width);
+    float           y   = 0.5f * (1.0f - ndc.y()) * static_cast<float>(Uniforms::height);
+
+    output_payload.world_position    = world_position;
+    output_payload.viewport_position = Eigen::Vector4f(x, y, clip_position.z(), clip_position.w());
 
     // Viewport transformation
 
     // Vertex normal transformation
+    Eigen::Vector4f normal4(payload.normal.x(), payload.normal.y(), payload.normal.z(), 0.0f);
+    Eigen::Vector3f world_normal = (Uniforms::inv_trans_M * normal4).head<3>();
+    world_normal.normalize();
+    output_payload.normal = world_normal;
 
     return output_payload;
 }
@@ -29,33 +46,34 @@ Vector3f phong_fragment_shader(
     const std::list<Light>& lights, const Camera& camera
 )
 {
-    // these lines below are just for compiling and can be deleted
-    (void)payload;
-    (void)material;
-    (void)lights;
-    (void)camera;
-    // these lines above are just for compiling and can be deleted
+    Vector3f result = Vector3f::Zero();
 
-    Vector3f result = {0, 0, 0};
+    // Ambient term (constant global ambient light)
+    const Vector3f ambient_light = Vector3f::Constant(0.1f);
+    result += material.ambient.cwiseProduct(ambient_light);
 
-    // ka,kd,ks can be got from material.ambient,material.diffuse,material.specular
+    Vector3f normal = payload.world_normal.normalized();
+    Vector3f view_vec = camera.position - payload.world_pos;
+    Vector3f view_dir = view_vec.squaredNorm() > 1e-6f ? view_vec.normalized() : Vector3f(0.0f, 0.0f, 1.0f);
 
-    // set ambient light intensity
+    for (const auto& light: lights) {
+        Vector3f light_vec   = light.position - payload.world_pos;
+        float    distance_sq = std::max(light_vec.squaredNorm(), 1e-4f);
+        Vector3f light_dir   = light_vec.normalized();
+        float    attenuation = light.intensity / distance_sq;
+        Vector3f radiance    = Vector3f::Ones() * attenuation;
 
-    // Light Direction
+        float    ndotl  = std::max(0.0f, normal.dot(light_dir));
+        Vector3f diffuse = material.diffuse.cwiseProduct(radiance) * ndotl;
 
-    // View Direction
+        Vector3f half_vec = (light_dir + view_dir).normalized();
+        float    ndoth    = std::max(0.0f, normal.dot(half_vec));
+        Vector3f specular = material.specular.cwiseProduct(radiance)
+                          * std::pow(ndoth, material.shininess);
 
-    // Half Vector
+        result += diffuse + specular;
+    }
 
-    // Light Attenuation
-
-    // Ambient
-
-    // Diffuse
-
-    // Specular
-
-    // set rendering result max threshold to 255
+    result = result.cwiseMax(Vector3f::Zero()).cwiseMin(Vector3f::Constant(1.0f));
     return result * 255.f;
 }


### PR DESCRIPTION
## Summary
- implement the vertex shader transforms and Blinn-Phong shading for the rasterizer pipeline
- add inside-triangle tests, barycentric interpolation, and fragment payload generation in the rasterizer

## Testing
- not run (build system not provided in container)


------
https://chatgpt.com/codex/tasks/task_b_68d6665ae26883339130f78f58d46c8f