### PR TITLE
Implement Chapter 1 software rasterizer pipeline

### DIFF
--- a/src1/render/rasterizer.cpp
+++ b/src1/render/rasterizer.cpp
@@ -15,6 +15,7 @@
 #include "../utils/math.hpp"
 
 using Eigen::Matrix4f;
+using Eigen::Vector2f;
 using Eigen::Vector2i;
 using Eigen::Vector3f;
 using Eigen::Vector4f;
@@ -68,24 +69,36 @@ float sign(Eigen::Vector2f p1, Eigen::Vector2f p2, Eigen::Vector2f p3)
 // 给定坐标(x,y)以及三角形的三个顶点坐标，判断(x,y)是否在三角形的内部
 bool Rasterizer::inside_triangle(int x, int y, const Vector4f* vertices)
 {
-    Vector3f v[3];
-    for (int i = 0; i < 3; i++) v[i] = {vertices[i].x(), vertices[i].y(), 1.0};
+    const Vector2f p(float(x) + 0.5f, float(y) + 0.5f);
+    const Vector2f v0(vertices[0].x(), vertices[0].y());
+    const Vector2f v1(vertices[1].x(), vertices[1].y());
+    const Vector2f v2(vertices[2].x(), vertices[2].y());
 
-    Vector3f p(float(x), float(y), 1.0f);
+    const float d0 = sign(p, v0, v1);
+    const float d1 = sign(p, v1, v2);
+    const float d2 = sign(p, v2, v0);
 
-    return false;
+    const bool has_neg = (d0 < 0.0f) || (d1 < 0.0f) || (d2 < 0.0f);
+    const bool has_pos = (d0 > 0.0f) || (d1 > 0.0f) || (d2 > 0.0f);
+
+    return !(has_neg && has_pos);
 }
 
 // 给定坐标(x,y)以及三角形的三个顶点坐标，计算(x,y)对应的重心坐标[alpha, beta, gamma]
 tuple<float, float, float> Rasterizer::compute_barycentric_2d(float x, float y, const Vector4f* v)
 {
-    float c1 = 0.f, c2 = 0.f, c3 = 0.f;
+    const float x0 = v[0].x(), y0 = v[0].y();
+    const float x1 = v[1].x(), y1 = v[1].y();
+    const float x2 = v[2].x(), y2 = v[2].y();
 
-    // these lines below are just for compiling and can be deleted
-    (void)x;
-    (void)y;
-    (void)v;
-    // these lines above are just for compiling and can be deleted
+    const float denom = x0 * (y1 - y2) + x1 * (y2 - y0) + x2 * (y0 - y1);
+    if (std::abs(denom) < 1e-8f) {
+        return {0.0f, 0.0f, 0.0f};
+    }
+
+    const float c1 = (x * (y1 - y2) + x1 * (y2 - y) + x2 * (y - y1)) / denom;
+    const float c2 = (x * (y2 - y0) + x2 * (y0 - y) + x0 * (y - y2)) / denom;
+    const float c3 = 1.0f - c1 - c2;
 
     return {c1, c2, c3};
 }
@@ -109,15 +122,75 @@ Vector3f Rasterizer::interpolate(
 // 对当前三角形进行光栅化
 void Rasterizer::rasterize_triangle(Triangle& t)
 {
-    // these lines below are just for compiling and can be deleted
-    (void)t;
-    FragmentShaderPayload payload;
-    // these lines above are just for compiling and can be deleted
+    const Vector4f v[3] = {t.viewport_pos[0], t.viewport_pos[1], t.viewport_pos[2]};
 
-    // if current pixel is in current triange:
-    // 1. interpolate depth(use projection correction algorithm)
-    // 2. interpolate vertex positon & normal(use function:interpolate())
-    // 3. push primitive into fragment queue
-    std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
-    Context::rasterizer_output_queue.push(payload);
+    const float min_x = std::min({v[0].x(), v[1].x(), v[2].x()});
+    const float max_x = std::max({v[0].x(), v[1].x(), v[2].x()});
+    const float min_y = std::min({v[0].y(), v[1].y(), v[2].y()});
+    const float max_y = std::max({v[0].y(), v[1].y(), v[2].y()});
+
+    int x_min = static_cast<int>(std::floor(min_x));
+    int x_max = static_cast<int>(std::ceil(max_x));
+    int y_min = static_cast<int>(std::floor(min_y));
+    int y_max = static_cast<int>(std::ceil(max_y));
+
+    x_min = std::max(0, x_min);
+    y_min = std::max(0, y_min);
+    x_max = std::min(Uniforms::width - 1, x_max);
+    y_max = std::min(Uniforms::height - 1, y_max);
+
+    if (x_min > x_max || y_min > y_max) {
+        return;
+    }
+
+    const Vector3f weight(v[0].w(), v[1].w(), v[2].w());
+    if (std::abs(weight[0]) < 1e-8f || std::abs(weight[1]) < 1e-8f || std::abs(weight[2]) < 1e-8f) {
+        return;
+    }
+    const Vector3f world_pos[3] = {
+        t.world_pos[0].head<3>(), t.world_pos[1].head<3>(), t.world_pos[2].head<3>()
+    };
+    const Vector3f normals[3] = {t.normal[0], t.normal[1], t.normal[2]};
+
+    for (int x = x_min; x <= x_max; ++x) {
+        for (int y = y_min; y <= y_max; ++y) {
+            if (!inside_triangle(x, y, v)) {
+                continue;
+            }
+
+            const float px = static_cast<float>(x) + 0.5f;
+            const float py = static_cast<float>(y) + 0.5f;
+            auto [alpha, beta, gamma] = compute_barycentric_2d(px, py, v);
+
+            const float denom = alpha / weight[0] + beta / weight[1] + gamma / weight[2];
+            if (std::abs(denom) < 1e-8f) {
+                continue;
+            }
+            const float Z = 1.0f / denom;
+
+            const float depth =
+                (alpha * v[0].z() / weight[0] + beta * v[1].z() / weight[1]
+                 + gamma * v[2].z() / weight[2])
+                * Z;
+
+            Vector3f interp_world =
+                interpolate(alpha, beta, gamma, world_pos[0], world_pos[1], world_pos[2], weight, Z);
+            Vector3f interp_normal =
+                interpolate(alpha, beta, gamma, normals[0], normals[1], normals[2], weight, Z);
+            if (interp_normal.norm() > 0.0f) {
+                interp_normal.normalize();
+            }
+
+            FragmentShaderPayload payload;
+            payload.world_pos    = interp_world;
+            payload.world_normal = interp_normal;
+            payload.x            = x;
+            payload.y            = y;
+            payload.depth        = depth;
+            payload.color        = Vector3f::Zero();
+
+            std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
+            Context::rasterizer_output_queue.push(payload);
+        }
+    }
 }

--- a/src1/render/shader.cpp
+++ b/src1/render/shader.cpp
@@ -16,10 +16,29 @@ VertexShaderPayload vertex_shader(const VertexShaderPayload& payload)
     VertexShaderPayload output_payload = payload;
 
     // Vertex position transformation
+    const Eigen::Matrix4f model = Uniforms::inv_trans_M.inverse().transpose();
+    const Eigen::Vector4f model_pos = payload.world_position;
+    const Eigen::Vector4f world_pos = model * model_pos;
+    const Eigen::Vector4f clip_pos  = Uniforms::MVP * model_pos;
+
+    Eigen::Vector3f ndc = clip_pos.head<3>() / clip_pos.w();
+    Eigen::Vector4f viewport_pos;
+    viewport_pos.x() = 0.5f * (ndc.x() + 1.0f) * static_cast<float>(Uniforms::width);
+    viewport_pos.y() = 0.5f * (ndc.y() + 1.0f) * static_cast<float>(Uniforms::height);
+    viewport_pos.z() = ndc.z();
+    viewport_pos.w() = clip_pos.w();
+
+    output_payload.world_position   = world_pos;
+    output_payload.viewport_position = viewport_pos;
 
     // Viewport transformation
 
     // Vertex normal transformation
+    Eigen::Vector3f normal = Uniforms::inv_trans_M.block<3, 3>(0, 0) * payload.normal;
+    if (normal.norm() > 0.0f) {
+        normal.normalize();
+    }
+    output_payload.normal = normal;
 
     return output_payload;
 }
@@ -29,33 +48,43 @@ Vector3f phong_fragment_shader(
     const std::list<Light>& lights, const Camera& camera
 )
 {
-    // these lines below are just for compiling and can be deleted
-    (void)payload;
-    (void)material;
-    (void)lights;
-    (void)camera;
-    // these lines above are just for compiling and can be deleted
+    Vector3f color = material.ambient;
 
-    Vector3f result = {0, 0, 0};
+    const Vector3f normal = payload.world_normal.normalized();
+    Vector3f       view_dir = camera.position - payload.world_pos;
+    const float    view_len = view_dir.norm();
+    if (view_len > 0.0f) {
+        view_dir /= view_len;
+    } else {
+        view_dir = Vector3f(0.0f, 0.0f, 1.0f);
+    }
 
-    // ka,kd,ks can be got from material.ambient,material.diffuse,material.specular
+    for (const auto& light: lights) {
+        Vector3f light_dir = light.position - payload.world_pos;
+        float     dist2     = light_dir.squaredNorm();
+        if (dist2 <= 1e-6f) {
+            dist2 = 1e-6f;
+        }
+        light_dir.normalize();
 
-    // set ambient light intensity
+        const float attenuation = light.intensity / dist2;
+        const Vector3f light_color = Vector3f::Constant(attenuation);
 
-    // Light Direction
+        const float diff = std::max(0.0f, normal.dot(light_dir));
+        const Vector3f diffuse = material.diffuse.cwiseProduct(light_color) * diff;
 
-    // View Direction
+        Vector3f half_vec = view_dir + light_dir;
+        float    spec = 0.0f;
+        if (half_vec.norm() > 0.0f && diff > 0.0f) {
+            half_vec.normalize();
+            spec = std::pow(std::max(0.0f, normal.dot(half_vec)), material.shininess);
+        }
+        const Vector3f specular = material.specular.cwiseProduct(light_color) * spec;
 
-    // Half Vector
+        color += diffuse + specular;
+    }
 
-    // Light Attenuation
-
-    // Ambient
-
-    // Diffuse
-
-    // Specular
-
-    // set rendering result max threshold to 255
-    return result * 255.f;
+    color = color.cwiseMax(Vector3f::Zero());
+    color = color.cwiseMin(Vector3f::Ones());
+    return color * 255.0f;
 }


### PR DESCRIPTION
## Summary
- implement triangle coverage tests and barycentric interpolation helpers for the rasterizer
- perform perspective-correct rasterization to feed fragment shading payloads
- implement vertex transformation and Blinn-Phong fragment shading

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d665eab16483338875b050e38a2d7d