### PR TITLE
Improve rasterizer stability

### DIFF
--- a/src1/render/rasterizer.cpp
+++ b/src1/render/rasterizer.cpp
@@ -68,24 +68,41 @@ float sign(Eigen::Vector2f p1, Eigen::Vector2f p2, Eigen::Vector2f p3)
 // 给定坐标(x,y)以及三角形的三个顶点坐标，判断(x,y)是否在三角形的内部
 bool Rasterizer::inside_triangle(int x, int y, const Vector4f* vertices)
 {
-    Vector3f v[3];
-    for (int i = 0; i < 3; i++) v[i] = {vertices[i].x(), vertices[i].y(), 1.0};
+    Eigen::Vector2f p(static_cast<float>(x) + 0.5f, static_cast<float>(y) + 0.5f);
+    Eigen::Vector2f v0(vertices[0].x(), vertices[0].y());
+    Eigen::Vector2f v1(vertices[1].x(), vertices[1].y());
+    Eigen::Vector2f v2(vertices[2].x(), vertices[2].y());
 
-    Vector3f p(float(x), float(y), 1.0f);
+    float d0 = sign(p, v0, v1);
+    float d1 = sign(p, v1, v2);
+    float d2 = sign(p, v2, v0);
 
-    return false;
+    bool has_neg = (d0 < 0.0f) || (d1 < 0.0f) || (d2 < 0.0f);
+    bool has_pos = (d0 > 0.0f) || (d1 > 0.0f) || (d2 > 0.0f);
+
+    return !(has_neg && has_pos);
 }
 
 // 给定坐标(x,y)以及三角形的三个顶点坐标，计算(x,y)对应的重心坐标[alpha, beta, gamma]
 tuple<float, float, float> Rasterizer::compute_barycentric_2d(float x, float y, const Vector4f* v)
 {
-    float c1 = 0.f, c2 = 0.f, c3 = 0.f;
+    float denom =
+        v[0].x() * (v[1].y() - v[2].y()) + v[1].x() * (v[2].y() - v[0].y())
+        + v[2].x() * (v[0].y() - v[1].y());
 
-    // these lines below are just for compiling and can be deleted
-    (void)x;
-    (void)y;
-    (void)v;
-    // these lines above are just for compiling and can be deleted
+    if (denom > -1e-6f && denom < 1e-6f) {
+        return {0.0f, 0.0f, 0.0f};
+    }
+
+    float c1 =
+        (x * (v[1].y() - v[2].y()) + (v[2].x() - v[1].x()) * y + v[1].x() * v[2].y()
+         - v[2].x() * v[1].y())
+        / denom;
+    float c2 =
+        (x * (v[2].y() - v[0].y()) + (v[0].x() - v[2].x()) * y + v[2].x() * v[0].y()
+         - v[0].x() * v[2].y())
+        / denom;
+    float c3 = 1.0f - c1 - c2;
 
     return {c1, c2, c3};
 }
@@ -109,15 +126,69 @@ Vector3f Rasterizer::interpolate(
 // 对当前三角形进行光栅化
 void Rasterizer::rasterize_triangle(Triangle& t)
 {
-    // these lines below are just for compiling and can be deleted
-    (void)t;
-    FragmentShaderPayload payload;
-    // these lines above are just for compiling and can be deleted
+    const Vector4f* v = t.viewport_pos;
 
-    // if current pixel is in current triange:
-    // 1. interpolate depth(use projection correction algorithm)
-    // 2. interpolate vertex positon & normal(use function:interpolate())
-    // 3. push primitive into fragment queue
-    std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
-    Context::rasterizer_output_queue.push(payload);
+    float min_x = std::min({v[0].x(), v[1].x(), v[2].x()});
+    float max_x = std::max({v[0].x(), v[1].x(), v[2].x()});
+    float min_y = std::min({v[0].y(), v[1].y(), v[2].y()});
+    float max_y = std::max({v[0].y(), v[1].y(), v[2].y()});
+
+    int x0 = std::max(0, static_cast<int>(std::floor(min_x)));
+    int x1 = std::min(Uniforms::width - 1, static_cast<int>(std::ceil(max_x)));
+    int y0 = std::max(0, static_cast<int>(std::floor(min_y)));
+    int y1 = std::min(Uniforms::height - 1, static_cast<int>(std::ceil(max_y)));
+
+    if (x0 > x1 || y0 > y1) {
+        return;
+    }
+
+    Vector3f weight(v[0].w(), v[1].w(), v[2].w());
+    Vector3f world_pos0 = t.world_pos[0].head<3>();
+    Vector3f world_pos1 = t.world_pos[1].head<3>();
+    Vector3f world_pos2 = t.world_pos[2].head<3>();
+    Vector3f normal0    = t.normal[0];
+    Vector3f normal1    = t.normal[1];
+    Vector3f normal2    = t.normal[2];
+
+    for (int x = x0; x <= x1; ++x) {
+        for (int y = y0; y <= y1; ++y) {
+            if (!inside_triangle(x, y, v)) {
+                continue;
+            }
+
+            float px = static_cast<float>(x) + 0.5f;
+            float py = static_cast<float>(y) + 0.5f;
+            auto  [alpha, beta, gamma] = compute_barycentric_2d(px, py, v);
+
+            float w_reciprocal = alpha / v[0].w() + beta / v[1].w() + gamma / v[2].w();
+            if (std::abs(w_reciprocal) < 1e-6f) {
+                continue;
+            }
+            float Z = 1.0f / w_reciprocal;
+
+            float depth =
+                (alpha * v[0].z() / v[0].w() + beta * v[1].z() / v[1].w()
+                 + gamma * v[2].z() / v[2].w())
+                * Z;
+            depth = 0.5f * (depth + 1.0f);
+            depth = std::clamp(depth, 0.0f, 1.0f);
+
+            FragmentShaderPayload payload;
+            payload.world_pos = interpolate(alpha, beta, gamma, world_pos0, world_pos1, world_pos2, weight, Z);
+            Vector3f interpolated_normal =
+                interpolate(alpha, beta, gamma, normal0, normal1, normal2, weight, Z);
+            if (interpolated_normal.norm() > 0.0f) {
+                interpolated_normal.normalize();
+            }
+            payload.world_normal = interpolated_normal;
+            payload.x     = x;
+            payload.y     = y;
+            payload.depth = depth;
+
+            {
+                std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
+                Context::rasterizer_output_queue.push(payload);
+            }
+        }
+    }
 }

--- a/src1/render/rasterizer_renderer.cpp
+++ b/src1/render/rasterizer_renderer.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <thread>
 #include <chrono>
+#include <mutex>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -85,6 +86,19 @@ void RasterizerRenderer::render(const Scene& scene)
             Context::rasterizer_finish = false;
             Context::fragment_finish   = false;
 
+            {
+                std::unique_lock<std::mutex> lock(Context::vertex_queue_mutex);
+                while (!Context::vertex_shader_output_queue.empty()) {
+                    Context::vertex_shader_output_queue.pop();
+                }
+            }
+            {
+                std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
+                while (!Context::rasterizer_output_queue.empty()) {
+                    Context::rasterizer_output_queue.pop();
+                }
+            }
+
             std::vector<std::thread> workers;
             for (int i = 0; i < n_vertex_threads; ++i) {
                 workers.emplace_back(&VertexProcessor::worker_thread, &vertex_processor);
@@ -101,10 +115,9 @@ void RasterizerRenderer::render(const Scene& scene)
             Uniforms::inv_trans_M = object->model().inverse().transpose();
             Uniforms::width       = static_cast<int>(this->width);
             Uniforms::height      = static_cast<int>(this->height);
-            // To do: 同步
-            Uniforms::material = object->mesh.material;
-            Uniforms::lights   = scene.lights;
-            Uniforms::camera   = scene.camera;
+            Uniforms::material    = object->mesh.material;
+            Uniforms::lights      = scene.lights;
+            Uniforms::camera      = scene.camera;
 
             // input object->mesh's vertices & faces & normals data
             const std::vector<float>&        vertices  = object->mesh.vertices.data;
@@ -191,6 +204,7 @@ void VertexProcessor::worker_thread()
 
 void FragmentProcessor::worker_thread()
 {
+    static std::mutex framebuffer_mutex;
     while (!Context::fragment_finish) {
         FragmentShaderPayload fragment;
         {
@@ -209,11 +223,14 @@ void FragmentProcessor::worker_thread()
             Context::rasterizer_output_queue.pop();
         }
         int index = (Uniforms::height - 1 - fragment.y) * Uniforms::width + fragment.x;
-        if (fragment.depth > Context::frame_buffer.depth_buffer[index]) {
+        if (index < 0 || index >= Uniforms::width * Uniforms::height) {
             continue;
         }
-        fragment.color =
-            fragment_shader_ptr(fragment, Uniforms::material, Uniforms::lights, Uniforms::camera);
-        Context::frame_buffer.set_pixel(index, fragment.depth, fragment.color);
+        std::unique_lock<std::mutex> pixel_lock(framebuffer_mutex);
+        if (fragment.depth <= Context::frame_buffer.depth_buffer[index]) {
+            fragment.color =
+                fragment_shader_ptr(fragment, Uniforms::material, Uniforms::lights, Uniforms::camera);
+            Context::frame_buffer.set_pixel(index, fragment.depth, fragment.color);
+        }
     }
 }

--- a/src1/render/shader.cpp
+++ b/src1/render/shader.cpp
@@ -16,10 +16,32 @@ VertexShaderPayload vertex_shader(const VertexShaderPayload& payload)
     VertexShaderPayload output_payload = payload;
 
     // Vertex position transformation
+    Eigen::Vector4f model_pos = payload.world_position;
+    Eigen::Vector4f clip_pos  = Uniforms::MVP * model_pos;
+
+    float w = clip_pos.w();
+    if (w > -1e-6f && w < 1e-6f) {
+        w = (w >= 0.0f ? 1e-6f : -1e-6f);
+    }
+    float inv_w = 1.0f / w;
+    Eigen::Vector3f ndc = clip_pos.head<3>() * inv_w;
+
+    Eigen::Vector4f viewport_pos = Eigen::Vector4f::Zero();
+    viewport_pos.x() = (ndc.x() + 1.0f) * 0.5f * static_cast<float>(Uniforms::width);
+    viewport_pos.y() = (ndc.y() + 1.0f) * 0.5f * static_cast<float>(Uniforms::height);
+    viewport_pos.z() = clip_pos.z();
+    viewport_pos.w() = w;
 
     // Viewport transformation
+    output_payload.viewport_position = viewport_pos;
 
     // Vertex normal transformation
+    Eigen::Vector4f normal4(payload.normal.x(), payload.normal.y(), payload.normal.z(), 0.0f);
+    Eigen::Vector3f world_normal = (Uniforms::inv_trans_M * normal4).head<3>().normalized();
+    output_payload.normal        = world_normal;
+
+    Eigen::Matrix4f model_matrix = Uniforms::inv_trans_M.inverse().transpose();
+    output_payload.world_position = model_matrix * model_pos;
 
     return output_payload;
 }
@@ -29,22 +51,20 @@ Vector3f phong_fragment_shader(
     const std::list<Light>& lights, const Camera& camera
 )
 {
-    // these lines below are just for compiling and can be deleted
-    (void)payload;
-    (void)material;
-    (void)lights;
-    (void)camera;
-    // these lines above are just for compiling and can be deleted
-
     Vector3f result = {0, 0, 0};
 
     // ka,kd,ks can be got from material.ambient,material.diffuse,material.specular
 
     // set ambient light intensity
+    const Vector3f ambient_light = Vector3f::Constant(0.1f);
+    result += material.ambient.cwiseProduct(ambient_light);
 
     // Light Direction
+    Vector3f point = payload.world_pos;
+    Vector3f normal = payload.world_normal.normalized();
 
     // View Direction
+    Vector3f view_dir = (camera.position - point).normalized();
 
     // Half Vector
 
@@ -55,6 +75,27 @@ Vector3f phong_fragment_shader(
     // Diffuse
 
     // Specular
+    for (const auto& light: lights) {
+        Vector3f light_dir = (light.position - point);
+        float    distance2 = std::max(light_dir.squaredNorm(), 1e-6f);
+        light_dir.normalize();
+
+        Vector3f attenuation = Vector3f::Constant(light.intensity / distance2);
+
+        Vector3f half_vec = (light_dir + view_dir).normalized();
+
+        float ndotl = std::max(0.0f, normal.dot(light_dir));
+        Vector3f diffuse = material.diffuse.cwiseProduct(attenuation) * ndotl;
+
+        float ndoth = std::max(0.0f, normal.dot(half_vec));
+        Vector3f specular = material.specular.cwiseProduct(attenuation)
+                             * std::pow(ndoth, material.shininess);
+
+        result += diffuse + specular;
+    }
+
+    result = result.cwiseMax(Vector3f::Zero());
+    result = result.cwiseMin(Vector3f::Ones());
 
     // set rendering result max threshold to 255
     return result * 255.f;


### PR DESCRIPTION
## Summary
- clear intermediate queues before starting each object's processing and guard frame-buffer updates with a mutex to prevent race-induced holes
- normalize interpolated depth to the [0,1] range and ignore nearly singular perspective weights for stable fragment generation

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_b_68d6780086d88333b5268609f460b42f