### PR TITLE
Fix perspective depth interpolation glitches

### DIFF
--- a/src1/render/rasterizer.cpp
+++ b/src1/render/rasterizer.cpp
@@ -23,39 +23,32 @@ using std::tuple;
 
 void Rasterizer::worker_thread()
 {
-    while (!Context::rasterizer_finish) {
-        VertexShaderPayload payload;
-        Triangle            triangle;
+    while (true) {
+        VertexShaderPayload payloads[3];
         {
-            if (Context::vertex_finish && Context::vertex_shader_output_queue.empty()) {
-                Context::rasterizer_finish = true;
-                return;
-            }
-            if (Context::vertex_shader_output_queue.size() < 3) {
-                continue;
-            }
             std::unique_lock<std::mutex> lock(Context::vertex_queue_mutex);
+
             if (Context::vertex_shader_output_queue.size() < 3) {
+                if (Context::vertex_finish) {
+                    Context::rasterizer_finish = true;
+                    return;
+                }
                 continue;
             }
-            for (size_t vertex_count = 0; vertex_count < 3; vertex_count++) {
-                payload = Context::vertex_shader_output_queue.front();
+
+            for (int i = 0; i < 3; ++i) {
+                payloads[i] = Context::vertex_shader_output_queue.front();
                 Context::vertex_shader_output_queue.pop();
-                if (vertex_count == 0) {
-                    triangle.world_pos[0]    = payload.world_position;
-                    triangle.viewport_pos[0] = payload.viewport_position;
-                    triangle.normal[0]       = payload.normal;
-                } else if (vertex_count == 1) {
-                    triangle.world_pos[1]    = payload.world_position;
-                    triangle.viewport_pos[1] = payload.viewport_position;
-                    triangle.normal[1]       = payload.normal;
-                } else {
-                    triangle.world_pos[2]    = payload.world_position;
-                    triangle.viewport_pos[2] = payload.viewport_position;
-                    triangle.normal[2]       = payload.normal;
-                }
             }
         }
+
+        Triangle triangle;
+        for (int i = 0; i < 3; ++i) {
+            triangle.world_pos[i]    = payloads[i].world_position;
+            triangle.viewport_pos[i] = payloads[i].viewport_position;
+            triangle.normal[i]       = payloads[i].normal;
+        }
+
         rasterize_triangle(triangle);
     }
 }
@@ -68,26 +61,36 @@ float sign(Eigen::Vector2f p1, Eigen::Vector2f p2, Eigen::Vector2f p3)
 // 给定坐标(x,y)以及三角形的三个顶点坐标，判断(x,y)是否在三角形的内部
 bool Rasterizer::inside_triangle(int x, int y, const Vector4f* vertices)
 {
-    Vector3f v[3];
-    for (int i = 0; i < 3; i++) v[i] = {vertices[i].x(), vertices[i].y(), 1.0};
-
-    Vector3f p(float(x), float(y), 1.0f);
-
-    return false;
+    float px = static_cast<float>(x) + 0.5f;
+    float py = static_cast<float>(y) + 0.5f;
+    auto  [alpha, beta, gamma] = compute_barycentric_2d(px, py, vertices);
+    constexpr float eps = 1e-4f;
+    return alpha >= -eps && beta >= -eps && gamma >= -eps;
 }
 
 // 给定坐标(x,y)以及三角形的三个顶点坐标，计算(x,y)对应的重心坐标[alpha, beta, gamma]
 tuple<float, float, float> Rasterizer::compute_barycentric_2d(float x, float y, const Vector4f* v)
 {
-    float c1 = 0.f, c2 = 0.f, c3 = 0.f;
+    const double x0 = static_cast<double>(v[0].x());
+    const double y0 = static_cast<double>(v[0].y());
+    const double x1 = static_cast<double>(v[1].x());
+    const double y1 = static_cast<double>(v[1].y());
+    const double x2 = static_cast<double>(v[2].x());
+    const double y2 = static_cast<double>(v[2].y());
 
-    // these lines below are just for compiling and can be deleted
-    (void)x;
-    (void)y;
-    (void)v;
-    // these lines above are just for compiling and can be deleted
+    const double denom = x0 * (y1 - y2) + x1 * (y2 - y0) + x2 * (y0 - y1);
 
-    return {c1, c2, c3};
+    if (std::abs(denom) < 1e-12) {
+        return {0.0f, 0.0f, 0.0f};
+    }
+
+    const double c1 =
+        (x * (y1 - y2) + (x2 - x1) * y + x1 * y2 - x2 * y1) / denom;
+    const double c2 =
+        (x * (y2 - y0) + (x0 - x2) * y + x2 * y0 - x0 * y2) / denom;
+    const double c3 = 1.0 - c1 - c2;
+
+    return {static_cast<float>(c1), static_cast<float>(c2), static_cast<float>(c3)};
 }
 
 // 对顶点的某一属性插值
@@ -109,15 +112,74 @@ Vector3f Rasterizer::interpolate(
 // 对当前三角形进行光栅化
 void Rasterizer::rasterize_triangle(Triangle& t)
 {
-    // these lines below are just for compiling and can be deleted
-    (void)t;
-    FragmentShaderPayload payload;
-    // these lines above are just for compiling and can be deleted
+    const Vector4f* v = t.viewport_pos;
 
-    // if current pixel is in current triange:
-    // 1. interpolate depth(use projection correction algorithm)
-    // 2. interpolate vertex positon & normal(use function:interpolate())
-    // 3. push primitive into fragment queue
-    std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
-    Context::rasterizer_output_queue.push(payload);
+    const float min_x = std::min({v[0].x(), v[1].x(), v[2].x()});
+    const float max_x = std::max({v[0].x(), v[1].x(), v[2].x()});
+    const float min_y = std::min({v[0].y(), v[1].y(), v[2].y()});
+    const float max_y = std::max({v[0].y(), v[1].y(), v[2].y()});
+
+    int x0 = std::max(0, static_cast<int>(std::floor(min_x)));
+    int x1 = std::min(Uniforms::width - 1, static_cast<int>(std::ceil(max_x)));
+    int y0 = std::max(0, static_cast<int>(std::floor(min_y)));
+    int y1 = std::min(Uniforms::height - 1, static_cast<int>(std::ceil(max_y)));
+
+    if (x0 > x1 || y0 > y1) {
+        return;
+    }
+
+    const float w0 = v[0].w();
+    const float w1 = v[1].w();
+    const float w2 = v[2].w();
+    if (std::abs(w0) < 1e-8f || std::abs(w1) < 1e-8f || std::abs(w2) < 1e-8f) {
+        return;
+    }
+
+    const Vector3f world_pos0 = t.world_pos[0].head<3>();
+    const Vector3f world_pos1 = t.world_pos[1].head<3>();
+    const Vector3f world_pos2 = t.world_pos[2].head<3>();
+    const Vector3f normal0    = t.normal[0];
+    const Vector3f normal1    = t.normal[1];
+    const Vector3f normal2    = t.normal[2];
+
+    for (int x = x0; x <= x1; ++x) {
+        for (int y = y0; y <= y1; ++y) {
+            if (!inside_triangle(x, y, v)) {
+                continue;
+            }
+
+            const float px = static_cast<float>(x) + 0.5f;
+            const float py = static_cast<float>(y) + 0.5f;
+            auto  [alpha, beta, gamma] = compute_barycentric_2d(px, py, v);
+
+            const float inv_w_sum = alpha / w0 + beta / w1 + gamma / w2;
+            if (inv_w_sum <= 0.0f || std::abs(inv_w_sum) < 1e-8f) {
+                continue;
+            }
+            const float w = 1.0f / inv_w_sum;
+
+            const float depth =
+                alpha * v[0].z() / w0 + beta * v[1].z() / w1 + gamma * v[2].z() / w2;
+
+            Eigen::Vector3f interp_world =
+                (alpha * world_pos0 / w0 + beta * world_pos1 / w1 + gamma * world_pos2 / w2)
+                * w;
+            Eigen::Vector3f interp_normal =
+                (alpha * normal0 / w0 + beta * normal1 / w1 + gamma * normal2 / w2) * w;
+            if (interp_normal.norm() > 0.0f) {
+                interp_normal.normalize();
+            }
+            FragmentShaderPayload payload;
+            payload.world_pos    = interp_world;
+            payload.world_normal = interp_normal;
+            payload.x     = x;
+            payload.y     = y;
+            payload.depth = depth;
+
+            {
+                std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
+                Context::rasterizer_output_queue.push(payload);
+            }
+        }
+    }
 }

--- a/src1/render/rasterizer_renderer.cpp
+++ b/src1/render/rasterizer_renderer.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <thread>
 #include <chrono>
+#include <mutex>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -85,6 +86,19 @@ void RasterizerRenderer::render(const Scene& scene)
             Context::rasterizer_finish = false;
             Context::fragment_finish   = false;
 
+            {
+                std::lock_guard<std::mutex> lock(Context::vertex_queue_mutex);
+                while (!Context::vertex_shader_output_queue.empty()) {
+                    Context::vertex_shader_output_queue.pop();
+                }
+            }
+            {
+                std::lock_guard<std::mutex> lock(Context::rasterizer_queue_mutex);
+                while (!Context::rasterizer_output_queue.empty()) {
+                    Context::rasterizer_output_queue.pop();
+                }
+            }
+
             std::vector<std::thread> workers;
             for (int i = 0; i < n_vertex_threads; ++i) {
                 workers.emplace_back(&VertexProcessor::worker_thread, &vertex_processor);
@@ -101,10 +115,9 @@ void RasterizerRenderer::render(const Scene& scene)
             Uniforms::inv_trans_M = object->model().inverse().transpose();
             Uniforms::width       = static_cast<int>(this->width);
             Uniforms::height      = static_cast<int>(this->height);
-            // To do: 同步
-            Uniforms::material = object->mesh.material;
-            Uniforms::lights   = scene.lights;
-            Uniforms::camera   = scene.camera;
+            Uniforms::material    = object->mesh.material;
+            Uniforms::lights      = scene.lights;
+            Uniforms::camera      = scene.camera;
 
             // input object->mesh's vertices & faces & normals data
             const std::vector<float>&        vertices  = object->mesh.vertices.data;

--- a/src1/render/shader.cpp
+++ b/src1/render/shader.cpp
@@ -1,6 +1,7 @@
 #include "rasterizer_renderer.h"
 #include "../utils/math.hpp"
 #include <cstdio>
+#include <cmath>
 
 #ifdef _WIN32
     #undef min
@@ -15,11 +16,31 @@ VertexShaderPayload vertex_shader(const VertexShaderPayload& payload)
 {
     VertexShaderPayload output_payload = payload;
 
-    // Vertex position transformation
+    const Eigen::Matrix4f model_matrix = Uniforms::inv_trans_M.inverse().transpose();
+    const Eigen::Vector4f model_pos    = payload.world_position;
+    const Eigen::Vector4f world_pos    = model_matrix * model_pos;
+    output_payload.world_position      = world_pos;
 
-    // Viewport transformation
+    const Eigen::Vector4f clip_pos = Uniforms::MVP * model_pos;
+    float                 w        = clip_pos.w();
+    if (std::abs(w) < 1e-6f) {
+        w = (w >= 0.0f ? 1e-6f : -1e-6f);
+    }
+    const Eigen::Vector3f ndc = clip_pos.head<3>() / w;
 
-    // Vertex normal transformation
+    Eigen::Vector4f viewport_pos = Eigen::Vector4f::Zero();
+    viewport_pos.x() = 0.5f * (ndc.x() + 1.0f) * static_cast<float>(Uniforms::width);
+    viewport_pos.y() = 0.5f * (ndc.y() + 1.0f) * static_cast<float>(Uniforms::height);
+    viewport_pos.z() = clip_pos.z();
+    viewport_pos.w() = w;
+    output_payload.viewport_position = viewport_pos;
+
+    const Eigen::Matrix3f normal_matrix = Uniforms::inv_trans_M.topLeftCorner<3, 3>();
+    Eigen::Vector3f       world_normal  = normal_matrix * payload.normal;
+    if (world_normal.norm() > 0.0f) {
+        world_normal.normalize();
+    }
+    output_payload.normal = world_normal;
 
     return output_payload;
 }
@@ -29,22 +50,20 @@ Vector3f phong_fragment_shader(
     const std::list<Light>& lights, const Camera& camera
 )
 {
-    // these lines below are just for compiling and can be deleted
-    (void)payload;
-    (void)material;
-    (void)lights;
-    (void)camera;
-    // these lines above are just for compiling and can be deleted
-
     Vector3f result = {0, 0, 0};
 
     // ka,kd,ks can be got from material.ambient,material.diffuse,material.specular
 
     // set ambient light intensity
+    const Vector3f ambient_light = Vector3f::Constant(0.1f);
+    result += material.ambient.cwiseProduct(ambient_light);
 
     // Light Direction
+    Vector3f point = payload.world_pos;
+    Vector3f normal = payload.world_normal.normalized();
 
     // View Direction
+    Vector3f view_dir = (camera.position - point).normalized();
 
     // Half Vector
 
@@ -55,6 +74,27 @@ Vector3f phong_fragment_shader(
     // Diffuse
 
     // Specular
+    for (const auto& light: lights) {
+        Vector3f light_dir = (light.position - point);
+        float    distance2 = std::max(light_dir.squaredNorm(), 1e-6f);
+        light_dir.normalize();
+
+        Vector3f attenuation = Vector3f::Constant(light.intensity / distance2);
+
+        Vector3f half_vec = (light_dir + view_dir).normalized();
+
+        float ndotl = std::max(0.0f, normal.dot(light_dir));
+        Vector3f diffuse = material.diffuse.cwiseProduct(attenuation) * ndotl;
+
+        float ndoth = std::max(0.0f, normal.dot(half_vec));
+        Vector3f specular = material.specular.cwiseProduct(attenuation)
+                             * std::pow(ndoth, material.shininess);
+
+        result += diffuse + specular;
+    }
+
+    result = result.cwiseMax(Vector3f::Zero());
+    result = result.cwiseMin(Vector3f::Ones());
 
     // set rendering result max threshold to 255
     return result * 255.f;


### PR DESCRIPTION
## Summary
- adjust the vertex shader viewport transform to preserve clip depth data alongside screen coordinates
- correct rasterizer perspective interpolation to compute depth in normalized device space while reusing consistent weights for world data

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_b_68d6780086d88333b5268609f460b42f