### PR TITLE
Refine rasterizer parallel pipeline and UI feedback

### DIFF
--- a/src1/render/graphics_interface.h
+++ b/src1/render/graphics_interface.h
@@ -4,6 +4,9 @@
 #include <memory>
 #include <functional>
 #include <queue>
+#include <condition_variable>
+#include <atomic>
+#include <cstddef>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -31,6 +34,10 @@ struct VertexShaderPayload
     Eigen::Vector4f viewport_position;
     /*! \~chinese 顶点法线 */
     Eigen::Vector3f normal;
+    /*! \~chinese 顶点在输入序列中的编号 */
+    std::size_t     vertex_index = 0;
+    /*! \~chinese 是否为终止任务 */
+    bool            terminate    = false;
 };
 
 /*!
@@ -153,8 +160,9 @@ public:
      * \param index 填充位置对应的一维索引
      * \param depth 当前着色点计算出的深度
      * \param color 当前着色点计算出的颜色值
+     * \return 若通过深度测试并成功写入像素则返回 true
      */
-    void set_pixel(int index, float depth, const Eigen::Vector3f& color);
+    bool set_pixel(int index, float depth, const Eigen::Vector3f& color);
 
     /*!
      * \~chinese
@@ -219,6 +227,10 @@ struct Context
     static std::queue<VertexShaderPayload> vertex_shader_output_queue;
     /*! \~chinese rasterizer的输出队列 */
     static std::queue<FragmentShaderPayload> rasterizer_output_queue;
+    /*! \~chinese 顶点着色器输出可用时的条件变量 */
+    static std::condition_variable vertex_output_cv;
+    /*! \~chinese 光栅化输出可用时的条件变量 */
+    static std::condition_variable rasterizer_output_cv;
 
     /*! \~chinese 标识顶点着色器是否全部执行完毕。 */
     volatile static bool vertex_finish;
@@ -229,6 +241,19 @@ struct Context
 
     /*! \~chinese 渲染使用的 frame buffer 。 */
     static FrameBuffer frame_buffer;
+
+    /*! \~chinese 顶点输入时的顺序计数器 */
+    static std::atomic<std::size_t> vertex_input_index;
+    /*! \~chinese 顶点处理完成的数量 */
+    static std::atomic<std::size_t> vertex_processed_count;
+    /*! \~chinese 顶点总数 */
+    static std::size_t              vertex_total_count;
+    /*! \~chinese 已按序写入输出队列的下标 */
+    static std::size_t              vertex_flush_index;
+    /*! \~chinese 顶点着色器输出的缓存 */
+    static std::vector<VertexShaderPayload> vertex_shader_output_buffer;
+    /*! \~chinese 顶点着色器输出是否就绪 */
+    static std::vector<char>                vertex_output_ready;
 };
 
 #endif // DANDELION_RENDER_GRAPHICS_INTERFACE_H

--- a/src1/render/rasterizer.cpp
+++ b/src1/render/rasterizer.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <mutex>
+#include <utility>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -23,14 +24,29 @@ using std::tuple;
 
 void Rasterizer::worker_thread()
 {
+    std::vector<FragmentShaderPayload> local_fragments;
+    local_fragments.reserve(512);
+
     while (true) {
         VertexShaderPayload payloads[3];
         {
             std::unique_lock<std::mutex> lock(Context::vertex_queue_mutex);
+            Context::vertex_output_cv.wait(lock, [&] {
+                return Context::vertex_shader_output_queue.size() >= 3 || Context::vertex_finish;
+            });
 
             if (Context::vertex_shader_output_queue.size() < 3) {
-                if (Context::vertex_finish) {
+                if (Context::vertex_finish && Context::vertex_shader_output_queue.empty()) {
+                    if (!local_fragments.empty()) {
+                        std::lock_guard<std::mutex> queue_lock(Context::rasterizer_queue_mutex);
+                        for (auto& fragment: local_fragments) {
+                            Context::rasterizer_output_queue.push(std::move(fragment));
+                        }
+                        local_fragments.clear();
+                        Context::rasterizer_output_cv.notify_all();
+                    }
                     Context::rasterizer_finish = true;
+                    Context::rasterizer_output_cv.notify_all();
                     return;
                 }
                 continue;
@@ -49,7 +65,18 @@ void Rasterizer::worker_thread()
             triangle.normal[i]       = payloads[i].normal;
         }
 
-        rasterize_triangle(triangle);
+        rasterize_triangle(triangle, local_fragments);
+
+        if (!local_fragments.empty()) {
+            {
+                std::lock_guard<std::mutex> queue_lock(Context::rasterizer_queue_mutex);
+                for (auto& fragment: local_fragments) {
+                    Context::rasterizer_output_queue.push(std::move(fragment));
+                }
+            }
+            Context::rasterizer_output_cv.notify_all();
+            local_fragments.clear();
+        }
     }
 }
 
@@ -110,7 +137,7 @@ Vector3f Rasterizer::interpolate(
 }
 
 // 对当前三角形进行光栅化
-void Rasterizer::rasterize_triangle(Triangle& t)
+void Rasterizer::rasterize_triangle(Triangle& t, std::vector<FragmentShaderPayload>& fragments)
 {
     const Vector4f* v = t.viewport_pos;
 
@@ -164,7 +191,7 @@ void Rasterizer::rasterize_triangle(Triangle& t)
             };
 
             FragmentShaderPayload payload;
-            payload.world_pos = perspective_correct(world_pos0, world_pos1, world_pos2);
+            payload.world_pos    = perspective_correct(world_pos0, world_pos1, world_pos2);
             payload.world_normal = perspective_correct(normal0, normal1, normal2);
             if (payload.world_normal.norm() > 0.0f) {
                 payload.world_normal.normalize();
@@ -173,10 +200,7 @@ void Rasterizer::rasterize_triangle(Triangle& t)
             payload.y     = y;
             payload.depth = depth;
 
-            {
-                std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
-                Context::rasterizer_output_queue.push(payload);
-            }
+            fragments.push_back(payload);
         }
     }
 }

--- a/src1/render/rasterizer.h
+++ b/src1/render/rasterizer.h
@@ -52,7 +52,7 @@ private:
      *
      * \param t 要进行光栅化的三角形
      */
-    void rasterize_triangle(Triangle& t);
+    void rasterize_triangle(Triangle& t, std::vector<FragmentShaderPayload>& fragments);
 
     /*! \~chinese 判断像素坐标 (x,y) 是否在给定三个顶点的三角形内 */
     static bool inside_triangle(int x, int y, const Eigen::Vector4f* vertices);

--- a/src1/render/rasterizer_renderer.cpp
+++ b/src1/render/rasterizer_renderer.cpp
@@ -4,6 +4,9 @@
 #include <thread>
 #include <chrono>
 #include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <algorithm>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -14,10 +17,41 @@
 
 using std::chrono::steady_clock;
 using std::size_t;
-using duration   = std::chrono::duration<float>;
-using time_point = std::chrono::time_point<steady_clock, duration>;
 using Eigen::Vector3f;
 using Eigen::Vector4f;
+
+namespace {
+struct StageThreadAllocation
+{
+    int vertex;
+    int rasterizer;
+    int fragment;
+};
+
+StageThreadAllocation distribute_stage_threads(int total_threads)
+{
+    int total = std::max(total_threads, 3);
+
+    StageThreadAllocation allocation{1, 1, 1};
+    total -= 3;
+
+    if (total > 0) {
+        int base = total / 3;
+        int extra = total % 3;
+        allocation.vertex += base;
+        allocation.rasterizer += base;
+        allocation.fragment += base;
+        if (extra > 0) {
+            ++allocation.vertex;
+        }
+        if (extra > 1) {
+            ++allocation.rasterizer;
+        }
+    }
+
+    return allocation;
+}
+} // namespace
 
 // vertex processor & rasterizer & fragement processor can visit
 // all the static variables below from Uniforms structure
@@ -38,10 +72,19 @@ std::mutex                        Context::vertex_queue_mutex;
 std::mutex                        Context::rasterizer_queue_mutex;
 std::queue<VertexShaderPayload>   Context::vertex_shader_output_queue;
 std::queue<FragmentShaderPayload> Context::rasterizer_output_queue;
+std::condition_variable           Context::vertex_output_cv;
+std::condition_variable           Context::rasterizer_output_cv;
 
 volatile bool Context::vertex_finish     = false;
 volatile bool Context::rasterizer_finish = false;
 volatile bool Context::fragment_finish   = false;
+
+std::atomic<std::size_t>           Context::vertex_input_index{0};
+std::atomic<std::size_t>           Context::vertex_processed_count{0};
+std::size_t                        Context::vertex_total_count = 0;
+std::size_t                        Context::vertex_flush_index = 0;
+std::vector<VertexShaderPayload>   Context::vertex_shader_output_buffer;
+std::vector<char>                  Context::vertex_output_ready;
 
 FrameBuffer Context::frame_buffer(Uniforms::width, Uniforms::height);
 
@@ -61,9 +104,32 @@ RasterizerRenderer::RasterizerRenderer(
 ) :
     width(engine.width), height(engine.height), n_vertex_threads(num_vertex_threads),
     n_rasterizer_threads(num_rasterizer_threads), n_fragment_threads(num_fragment_threads),
+    total_parallel_threads(num_vertex_threads + num_rasterizer_threads + num_fragment_threads),
+    pipeline_mode(PipelineMode::Parallel),
     vertex_processor(), rasterizer(), fragment_processor(), rendering_res(engine.rendering_res)
 {
     logger = get_logger("Rasterizer Renderer");
+    set_parallel_thread_count(total_parallel_threads);
+}
+
+void RasterizerRenderer::set_pipeline_mode(PipelineMode mode)
+{
+    pipeline_mode = mode;
+}
+
+void RasterizerRenderer::set_parallel_thread_count(int count)
+{
+    int clamped = std::max(3, count);
+    total_parallel_threads = clamped;
+    auto allocation        = distribute_stage_threads(clamped);
+    n_vertex_threads       = allocation.vertex;
+    n_rasterizer_threads   = allocation.rasterizer;
+    n_fragment_threads     = allocation.fragment;
+}
+
+int RasterizerRenderer::parallel_thread_count() const
+{
+    return total_parallel_threads;
 }
 
 // 光栅化渲染器的渲染调用接口
@@ -76,10 +142,29 @@ void RasterizerRenderer::render(const Scene& scene)
     Context::frame_buffer.clear(BufferType::Color | BufferType::Depth);
     this->rendering_res.clear();
     // run time statistics
-    time_point begin_time                  = steady_clock::now();
+    auto begin_time = steady_clock::now();
     Camera     cam                         = scene.camera;
     vertex_processor.vertex_shader_ptr     = vertex_shader;
     fragment_processor.fragment_shader_ptr = phong_fragment_shader;
+    StageThreadAllocation active_counts;
+    int                   total_threads = 3;
+    if (pipeline_mode == PipelineMode::Serial) {
+        active_counts = {1, 1, 1};
+    } else {
+        active_counts   = {n_vertex_threads, n_rasterizer_threads, n_fragment_threads};
+        total_threads   = total_parallel_threads;
+    }
+
+    int vertex_threads     = active_counts.vertex;
+    int rasterizer_threads = active_counts.rasterizer;
+    int fragment_threads   = active_counts.fragment;
+
+    const char* mode_name = pipeline_mode == PipelineMode::Serial ? "Serial" : "Parallel";
+    logger->info(
+        "Rasterizer rendering started (mode: {}, total: {}, vertex: {}, rasterizer: {}, fragment: {})",
+        mode_name, total_threads, vertex_threads, rasterizer_threads, fragment_threads
+    );
+
     for (const auto& group: scene.groups) {
         for (const auto& object: group->objects) {
             Context::vertex_finish     = false;
@@ -99,14 +184,33 @@ void RasterizerRenderer::render(const Scene& scene)
                 }
             }
 
+            const std::vector<float>&        vertices  = object->mesh.vertices.data;
+            const std::vector<unsigned int>& faces     = object->mesh.faces.data;
+            const std::vector<float>&        normals   = object->mesh.normals.data;
+            size_t                           num_indices = faces.size();
+
+            Context::vertex_input_index.store(0);
+            Context::vertex_processed_count.store(0);
+            Context::vertex_total_count = num_indices;
+            Context::vertex_flush_index = 0;
+            Context::vertex_shader_output_buffer.assign(num_indices, VertexShaderPayload());
+            Context::vertex_output_ready.assign(num_indices, 0);
+
+            if (num_indices == 0) {
+                Context::vertex_finish     = true;
+                Context::rasterizer_finish = true;
+                Context::vertex_output_cv.notify_all();
+                Context::rasterizer_output_cv.notify_all();
+            }
+
             std::vector<std::thread> workers;
-            for (int i = 0; i < n_vertex_threads; ++i) {
+            for (int i = 0; i < vertex_threads; ++i) {
                 workers.emplace_back(&VertexProcessor::worker_thread, &vertex_processor);
             }
-            for (int i = 0; i < n_rasterizer_threads; ++i) {
+            for (int i = 0; i < rasterizer_threads; ++i) {
                 workers.emplace_back(&Rasterizer::worker_thread, &rasterizer);
             }
-            for (int i = 0; i < n_fragment_threads; ++i) {
+            for (int i = 0; i < fragment_threads; ++i) {
                 workers.emplace_back(&FragmentProcessor::worker_thread, &fragment_processor);
             }
 
@@ -119,14 +223,8 @@ void RasterizerRenderer::render(const Scene& scene)
             Uniforms::lights      = scene.lights;
             Uniforms::camera      = scene.camera;
 
-            // input object->mesh's vertices & faces & normals data
-            const std::vector<float>&        vertices  = object->mesh.vertices.data;
-            const std::vector<unsigned int>& faces     = object->mesh.faces.data;
-            const std::vector<float>&        normals   = object->mesh.normals.data;
-            size_t                           num_faces = faces.size();
-
             // process vertices
-            for (size_t i = 0; i < num_faces; i += 3) {
+            for (size_t i = 0; i < num_indices; i += 3) {
                 for (size_t j = 0; j < 3; j++) {
                     size_t idx = faces[i + j];
                     vertex_processor.input_vertices(
@@ -137,9 +235,11 @@ void RasterizerRenderer::render(const Scene& scene)
                     );
                 }
             }
-            vertex_processor.input_vertices(
-                Eigen::Vector4f(0, 0, 0, -1.0f), Eigen::Vector3f::Zero()
-            );
+            for (int i = 0; i < vertex_threads; ++i) {
+                vertex_processor.input_vertices(
+                    Eigen::Vector4f(0, 0, 0, -1.0f), Eigen::Vector3f::Zero()
+                );
+            }
             for (auto& worker: workers) {
                 if (worker.joinable()) {
                     worker.join();
@@ -148,10 +248,13 @@ void RasterizerRenderer::render(const Scene& scene)
         }
     }
 
-    time_point end_time           = steady_clock::now();
-    duration   rendering_duration = end_time - begin_time;
+    auto end_time           = steady_clock::now();
+    auto rendering_duration = std::chrono::duration_cast<std::chrono::duration<double>>(end_time - begin_time);
 
-    this->logger->info("rendering takes {:.6f} seconds", rendering_duration.count());
+    this->logger->info(
+        "Rasterizer rendering finished (mode: {}) in {:.6f} seconds", mode_name,
+        rendering_duration.count()
+    );
 
     for (long unsigned int i = 0; i < Context::frame_buffer.depth_buffer.size(); i++) {
         rendering_res.push_back(
@@ -168,69 +271,97 @@ void RasterizerRenderer::render(const Scene& scene)
 
 void VertexProcessor::input_vertices(const Vector4f& positions, const Vector3f& normals)
 {
-    std::unique_lock<std::mutex> lock(queue_mutex);
-    VertexShaderPayload          payload;
-    payload.world_position = positions;
-    payload.normal         = normals;
-    vertex_queue.push(payload);
+    VertexShaderPayload payload;
+    payload.world_position  = positions;
+    payload.viewport_position = Eigen::Vector4f::Zero();
+    payload.normal          = normals;
+    if (positions.w() == -1.0f) {
+        payload.terminate = true;
+    } else {
+        payload.vertex_index = Context::vertex_input_index.fetch_add(1);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex);
+        vertex_queue.push(payload);
+    }
+
+    if (payload.terminate) {
+        queue_cv.notify_all();
+    } else {
+        queue_cv.notify_one();
+    }
 }
 
 void VertexProcessor::worker_thread()
 {
     while (true) {
-        std::unique_lock<std::mutex> lock(queue_mutex);
-
-        if (vertex_queue.empty()) {
-            if (Context::vertex_finish) {
-                return;
-            }
-            lock.unlock();
-            std::this_thread::yield();
-            continue;
+        VertexShaderPayload payload;
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex);
+            queue_cv.wait(lock, [&] { return !vertex_queue.empty(); });
+            payload = vertex_queue.front();
+            vertex_queue.pop();
         }
 
-        VertexShaderPayload payload = vertex_queue.front();
-        vertex_queue.pop();
-
-        if (payload.world_position.w() == -1.0f) {
-            Context::vertex_finish = true;
+        if (payload.terminate) {
+            queue_cv.notify_all();
             return;
         }
 
         VertexShaderPayload output_payload = vertex_shader_ptr(payload);
 
         {
-            std::unique_lock<std::mutex> output_lock(Context::vertex_queue_mutex);
-            Context::vertex_shader_output_queue.push(output_payload);
+            std::lock_guard<std::mutex> output_lock(Context::vertex_queue_mutex);
+            if (payload.vertex_index < Context::vertex_shader_output_buffer.size()) {
+                Context::vertex_shader_output_buffer[payload.vertex_index] = output_payload;
+                Context::vertex_output_ready[payload.vertex_index]          = 1;
+                while (
+                    Context::vertex_flush_index < Context::vertex_total_count
+                    && Context::vertex_output_ready[Context::vertex_flush_index]
+                ) {
+                    Context::vertex_shader_output_queue.push(
+                        Context::vertex_shader_output_buffer[Context::vertex_flush_index]
+                    );
+                    ++Context::vertex_flush_index;
+                }
+            }
+        }
+
+        Context::vertex_output_cv.notify_all();
+
+        std::size_t processed = ++Context::vertex_processed_count;
+        if (processed == Context::vertex_total_count) {
+            Context::vertex_finish = true;
+            Context::vertex_output_cv.notify_all();
         }
     }
 }
 
 void FragmentProcessor::worker_thread()
 {
-    while (!Context::fragment_finish) {
+    while (true) {
         FragmentShaderPayload fragment;
         {
-            if (Context::rasterizer_finish && Context::rasterizer_output_queue.empty()) {
-                Context::fragment_finish = true;
-                return;
-            }
-            if (Context::rasterizer_output_queue.empty()) {
-                continue;
-            }
             std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
+            Context::rasterizer_output_cv.wait(lock, [&] {
+                return !Context::rasterizer_output_queue.empty() || Context::rasterizer_finish;
+            });
             if (Context::rasterizer_output_queue.empty()) {
+                if (Context::rasterizer_finish) {
+                    Context::fragment_finish = true;
+                    return;
+                }
                 continue;
             }
             fragment = Context::rasterizer_output_queue.front();
             Context::rasterizer_output_queue.pop();
         }
         int index = (Uniforms::height - 1 - fragment.y) * Uniforms::width + fragment.x;
-        if (fragment.depth > Context::frame_buffer.depth_buffer[index]) {
-            continue;
-        }
         fragment.color =
             fragment_shader_ptr(fragment, Uniforms::material, Uniforms::lights, Uniforms::camera);
-        Context::frame_buffer.set_pixel(index, fragment.depth, fragment.color);
+        if (!Context::frame_buffer.set_pixel(index, fragment.depth, fragment.color)) {
+            continue;
+        }
     }
 }

--- a/src1/render/rasterizer_renderer.h
+++ b/src1/render/rasterizer_renderer.h
@@ -3,6 +3,7 @@
 
 #include <list>
 #include <queue>
+#include <condition_variable>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -53,6 +54,8 @@ private:
     std::queue<VertexShaderPayload> vertex_queue;
     /*! \~chinese 保护顶点队列的互斥锁 */
     std::mutex                      queue_mutex;
+    /*! \~chinese 顶点输入队列的条件变量 */
+    std::condition_variable         queue_cv;
 };
 
 /*!

--- a/src1/render/render_engine.h
+++ b/src1/render/render_engine.h
@@ -39,6 +39,17 @@ enum class RendererType
 /*!
  * \ingroup rendering
  * \~chinese
+ * \brief 光栅化流水线的运行模式。
+ */
+enum class PipelineMode
+{
+    Serial,
+    Parallel
+};
+
+/*!
+ * \ingroup rendering
+ * \~chinese
  * \brief 离线渲染的执行入口
  */
 class RenderEngine
@@ -65,6 +76,30 @@ public:
      * \param type 渲染器类型
      */
     void render(Scene& scene, RendererType type);
+
+    /*!
+     * \~chinese
+     * \brief 设置光栅化流水线的运行模式
+     */
+    void set_rasterizer_pipeline_mode(PipelineMode mode);
+
+    /*!
+     * \~chinese
+     * \brief 获取当前光栅化流水线的运行模式
+     */
+    PipelineMode get_rasterizer_pipeline_mode() const;
+
+    /*!
+     * \~chinese
+     * \brief 设置并行流水线下的总线程数
+     */
+    void set_rasterizer_parallel_thread_count(int threads);
+
+    /*!
+     * \~chinese
+     * \brief 获取并行流水线下配置的总线程数
+     */
+    int get_rasterizer_parallel_thread_count() const;
     /*! \~chinese 渲染结果预览的背景颜色 */
     static Eigen::Vector3f background_color;
 
@@ -72,6 +107,10 @@ public:
     std::unique_ptr<RasterizerRenderer> rasterizer_render;
     /*! \~chinese whitted style渲染器 */
     std::unique_ptr<WhittedRenderer> whitted_render;
+
+private:
+    PipelineMode rasterizer_mode;
+    int          rasterizer_parallel_threads;
 };
 
 /*!
@@ -91,11 +130,32 @@ public:
     /*! \~chinese 光栅化渲染器的渲染调用接口*/
     void render(const Scene& scene);
 
+    /*!
+     * \~chinese
+     * \brief 配置流水线模式。
+     */
+    void set_pipeline_mode(PipelineMode mode);
+
+    /*!
+     * \~chinese
+     * \brief 设置并行模式下的总线程数
+     */
+    void set_parallel_thread_count(int count);
+
+    /*!
+     * \~chinese
+     * \brief 获取并行模式下配置的总线程数
+     */
+    int parallel_thread_count() const;
+
     float& width;
     float& height;
     int    n_vertex_threads;
     int    n_rasterizer_threads;
     int    n_fragment_threads;
+    int    total_parallel_threads;
+
+    PipelineMode pipeline_mode;
 
     // initialize vertex processor
     VertexProcessor vertex_processor;


### PR DESCRIPTION
## Summary
- rebalance the rasterizer parallel pipeline by distributing a configurable total thread count across the vertex, rasterizer, and fragment stages and logging the allocation
- batch fragment generation before handing work to the fragment shader stage, guard framebuffer updates with a locked depth test, and improve render timing precision
- surface the stage-level thread allocation in the UI so that the configured total thread count is easier to understand

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_b_68d7a901e4dc833397caac040027f432