### PR TITLE
Optimize rasterizer pipeline parallel batching

### DIFF
--- a/src1/render/graphics_interface.h
+++ b/src1/render/graphics_interface.h
@@ -4,6 +4,10 @@
 #include <memory>
 #include <functional>
 #include <queue>
+#include <condition_variable>
+#include <atomic>
+#include <cstddef>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -31,6 +35,10 @@ struct VertexShaderPayload
     Eigen::Vector4f viewport_position;
     /*! \~chinese 顶点法线 */
     Eigen::Vector3f normal;
+    /*! \~chinese 顶点在输入序列中的编号 */
+    std::size_t     vertex_index = 0;
+    /*! \~chinese 是否为终止任务 */
+    bool            terminate    = false;
 };
 
 /*!
@@ -190,6 +198,8 @@ struct Uniforms
     static Eigen::Matrix4f MVP;
     /*! \~chinese 当前渲染物体的model.inverse().transpose() */
     static Eigen::Matrix4f inv_trans_M;
+    /*! \~chinese 当前渲染物体的模型矩阵 */
+    static Eigen::Matrix4f model;
     ///@{
     /*! \~chinese 当前成像平面的长和宽 */
     static int width;
@@ -216,9 +226,13 @@ struct Context
     /*! \~chinese 保护队列的互斥锁 */
     static std::mutex rasterizer_queue_mutex;
     /*! \~chinese vertex shader的输出队列 */
-    static std::queue<VertexShaderPayload> vertex_shader_output_queue;
+    static std::queue<VertexShaderPayload>            vertex_shader_output_queue;
     /*! \~chinese rasterizer的输出队列 */
-    static std::queue<FragmentShaderPayload> rasterizer_output_queue;
+    static std::queue<std::vector<FragmentShaderPayload>> rasterizer_output_queue;
+    /*! \~chinese 顶点着色器输出可用时的条件变量 */
+    static std::condition_variable vertex_output_cv;
+    /*! \~chinese 光栅化输出可用时的条件变量 */
+    static std::condition_variable rasterizer_output_cv;
 
     /*! \~chinese 标识顶点着色器是否全部执行完毕。 */
     volatile static bool vertex_finish;
@@ -229,6 +243,19 @@ struct Context
 
     /*! \~chinese 渲染使用的 frame buffer 。 */
     static FrameBuffer frame_buffer;
+
+    /*! \~chinese 顶点输入时的顺序计数器 */
+    static std::atomic<std::size_t> vertex_input_index;
+    /*! \~chinese 顶点处理完成的数量 */
+    static std::atomic<std::size_t> vertex_processed_count;
+    /*! \~chinese 顶点总数 */
+    static std::size_t              vertex_total_count;
+    /*! \~chinese 顶点着色器输出的缓存 */
+    static std::vector<VertexShaderPayload> vertex_shader_output_buffer;
+    /*! \~chinese 顶点着色器输出是否就绪 */
+    static std::vector<char>                vertex_output_ready;
+    /*! \~chinese 对应三角形是否已入队 */
+    static std::vector<char>                triangle_enqueued;
 };
 
 #endif // DANDELION_RENDER_GRAPHICS_INTERFACE_H

--- a/src1/render/rasterizer.cpp
+++ b/src1/render/rasterizer.cpp
@@ -27,10 +27,14 @@ void Rasterizer::worker_thread()
         VertexShaderPayload payloads[3];
         {
             std::unique_lock<std::mutex> lock(Context::vertex_queue_mutex);
+            Context::vertex_output_cv.wait(lock, [&] {
+                return Context::vertex_shader_output_queue.size() >= 3 || Context::vertex_finish;
+            });
 
             if (Context::vertex_shader_output_queue.size() < 3) {
-                if (Context::vertex_finish) {
+                if (Context::vertex_finish && Context::vertex_shader_output_queue.empty()) {
                     Context::rasterizer_finish = true;
+                    Context::rasterizer_output_cv.notify_all();
                     return;
                 }
                 continue;
@@ -135,6 +139,9 @@ void Rasterizer::rasterize_triangle(Triangle& t)
     Vector3f normal1    = t.normal[1];
     Vector3f normal2    = t.normal[2];
 
+    std::vector<FragmentShaderPayload> fragments;
+    fragments.reserve(static_cast<std::size_t>((x1 - x0 + 1) * (y1 - y0 + 1)));
+
     for (int x = x0; x <= x1; ++x) {
         for (int y = y0; y <= y1; ++y) {
             if (!inside_triangle(x, y, v)) {
@@ -164,7 +171,7 @@ void Rasterizer::rasterize_triangle(Triangle& t)
             };
 
             FragmentShaderPayload payload;
-            payload.world_pos = perspective_correct(world_pos0, world_pos1, world_pos2);
+            payload.world_pos    = perspective_correct(world_pos0, world_pos1, world_pos2);
             payload.world_normal = perspective_correct(normal0, normal1, normal2);
             if (payload.world_normal.norm() > 0.0f) {
                 payload.world_normal.normalize();
@@ -173,10 +180,15 @@ void Rasterizer::rasterize_triangle(Triangle& t)
             payload.y     = y;
             payload.depth = depth;
 
-            {
-                std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
-                Context::rasterizer_output_queue.push(payload);
-            }
+            fragments.push_back(payload);
         }
+    }
+
+    if (!fragments.empty()) {
+        {
+            std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
+            Context::rasterizer_output_queue.push(std::move(fragments));
+        }
+        Context::rasterizer_output_cv.notify_all();
     }
 }

--- a/src1/render/rasterizer_renderer.cpp
+++ b/src1/render/rasterizer_renderer.cpp
@@ -4,6 +4,9 @@
 #include <thread>
 #include <chrono>
 #include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <algorithm>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -14,8 +17,6 @@
 
 using std::chrono::steady_clock;
 using std::size_t;
-using duration   = std::chrono::duration<float>;
-using time_point = std::chrono::time_point<steady_clock, duration>;
 using Eigen::Vector3f;
 using Eigen::Vector4f;
 
@@ -23,6 +24,7 @@ using Eigen::Vector4f;
 // all the static variables below from Uniforms structure
 Eigen::Matrix4f Uniforms::MVP;
 Eigen::Matrix4f Uniforms::inv_trans_M;
+Eigen::Matrix4f Uniforms::model = Eigen::Matrix4f::Identity();
 int             Uniforms::width  = 0;
 int             Uniforms::height = 0;
 
@@ -36,12 +38,21 @@ Camera&           Uniforms::camera   = ini_camera;
 
 std::mutex                        Context::vertex_queue_mutex;
 std::mutex                        Context::rasterizer_queue_mutex;
-std::queue<VertexShaderPayload>   Context::vertex_shader_output_queue;
-std::queue<FragmentShaderPayload> Context::rasterizer_output_queue;
+std::queue<VertexShaderPayload>            Context::vertex_shader_output_queue;
+std::queue<std::vector<FragmentShaderPayload>> Context::rasterizer_output_queue;
+std::condition_variable           Context::vertex_output_cv;
+std::condition_variable           Context::rasterizer_output_cv;
 
 volatile bool Context::vertex_finish     = false;
 volatile bool Context::rasterizer_finish = false;
 volatile bool Context::fragment_finish   = false;
+
+std::atomic<std::size_t>           Context::vertex_input_index{0};
+std::atomic<std::size_t>           Context::vertex_processed_count{0};
+std::size_t                        Context::vertex_total_count = 0;
+std::vector<VertexShaderPayload>   Context::vertex_shader_output_buffer;
+std::vector<char>                  Context::vertex_output_ready;
+std::vector<char>                  Context::triangle_enqueued;
 
 FrameBuffer Context::frame_buffer(Uniforms::width, Uniforms::height);
 
@@ -61,9 +72,28 @@ RasterizerRenderer::RasterizerRenderer(
 ) :
     width(engine.width), height(engine.height), n_vertex_threads(num_vertex_threads),
     n_rasterizer_threads(num_rasterizer_threads), n_fragment_threads(num_fragment_threads),
+    pipeline_mode(PipelineMode::Parallel),
     vertex_processor(), rasterizer(), fragment_processor(), rendering_res(engine.rendering_res)
 {
     logger = get_logger("Rasterizer Renderer");
+}
+
+void RasterizerRenderer::set_pipeline_mode(PipelineMode mode)
+{
+    pipeline_mode = mode;
+}
+
+void RasterizerRenderer::set_parallel_thread_count(int count)
+{
+    int clamped          = std::max(1, count);
+    n_vertex_threads     = clamped;
+    n_rasterizer_threads = clamped;
+    n_fragment_threads   = clamped;
+}
+
+int RasterizerRenderer::parallel_thread_count() const
+{
+    return n_vertex_threads;
 }
 
 // 光栅化渲染器的渲染调用接口
@@ -76,10 +106,20 @@ void RasterizerRenderer::render(const Scene& scene)
     Context::frame_buffer.clear(BufferType::Color | BufferType::Depth);
     this->rendering_res.clear();
     // run time statistics
-    time_point begin_time                  = steady_clock::now();
+    auto       begin_time                  = steady_clock::now();
     Camera     cam                         = scene.camera;
     vertex_processor.vertex_shader_ptr     = vertex_shader;
     fragment_processor.fragment_shader_ptr = phong_fragment_shader;
+    int vertex_threads     = pipeline_mode == PipelineMode::Serial ? 1 : n_vertex_threads;
+    int rasterizer_threads = pipeline_mode == PipelineMode::Serial ? 1 : n_rasterizer_threads;
+    int fragment_threads   = pipeline_mode == PipelineMode::Serial ? 1 : n_fragment_threads;
+
+    const char* mode_name = pipeline_mode == PipelineMode::Serial ? "Serial" : "Parallel";
+    logger->info(
+        "Rasterizer rendering started (mode: {}, vertex: {}, rasterizer: {}, fragment: {})",
+        mode_name, vertex_threads, rasterizer_threads, fragment_threads
+    );
+
     for (const auto& group: scene.groups) {
         for (const auto& object: group->objects) {
             Context::vertex_finish     = false;
@@ -99,34 +139,49 @@ void RasterizerRenderer::render(const Scene& scene)
                 }
             }
 
+            const std::vector<float>&        vertices  = object->mesh.vertices.data;
+            const std::vector<unsigned int>& faces     = object->mesh.faces.data;
+            const std::vector<float>&        normals   = object->mesh.normals.data;
+            size_t                           num_indices = faces.size();
+
+            Context::vertex_input_index.store(0);
+            Context::vertex_processed_count.store(0);
+            Context::vertex_total_count = num_indices;
+            Context::vertex_shader_output_buffer.assign(num_indices, VertexShaderPayload());
+            Context::vertex_output_ready.assign(num_indices, 0);
+            Context::triangle_enqueued.assign((num_indices + 2) / 3, 0);
+
+            if (num_indices == 0) {
+                Context::vertex_finish     = true;
+                Context::rasterizer_finish = true;
+                Context::triangle_enqueued.clear();
+                Context::vertex_output_cv.notify_all();
+                Context::rasterizer_output_cv.notify_all();
+            }
+
             std::vector<std::thread> workers;
-            for (int i = 0; i < n_vertex_threads; ++i) {
+            for (int i = 0; i < vertex_threads; ++i) {
                 workers.emplace_back(&VertexProcessor::worker_thread, &vertex_processor);
             }
-            for (int i = 0; i < n_rasterizer_threads; ++i) {
+            for (int i = 0; i < rasterizer_threads; ++i) {
                 workers.emplace_back(&Rasterizer::worker_thread, &rasterizer);
             }
-            for (int i = 0; i < n_fragment_threads; ++i) {
+            for (int i = 0; i < fragment_threads; ++i) {
                 workers.emplace_back(&FragmentProcessor::worker_thread, &fragment_processor);
             }
 
             // set Uniforms for vertex shader
             Uniforms::MVP         = cam.projection() * cam.view() * object->model();
             Uniforms::inv_trans_M = object->model().inverse().transpose();
+            Uniforms::model       = object->model();
             Uniforms::width       = static_cast<int>(this->width);
             Uniforms::height      = static_cast<int>(this->height);
             Uniforms::material    = object->mesh.material;
             Uniforms::lights      = scene.lights;
             Uniforms::camera      = scene.camera;
 
-            // input object->mesh's vertices & faces & normals data
-            const std::vector<float>&        vertices  = object->mesh.vertices.data;
-            const std::vector<unsigned int>& faces     = object->mesh.faces.data;
-            const std::vector<float>&        normals   = object->mesh.normals.data;
-            size_t                           num_faces = faces.size();
-
             // process vertices
-            for (size_t i = 0; i < num_faces; i += 3) {
+            for (size_t i = 0; i < num_indices; i += 3) {
                 for (size_t j = 0; j < 3; j++) {
                     size_t idx = faces[i + j];
                     vertex_processor.input_vertices(
@@ -137,9 +192,11 @@ void RasterizerRenderer::render(const Scene& scene)
                     );
                 }
             }
-            vertex_processor.input_vertices(
-                Eigen::Vector4f(0, 0, 0, -1.0f), Eigen::Vector3f::Zero()
-            );
+            for (int i = 0; i < vertex_threads; ++i) {
+                vertex_processor.input_vertices(
+                    Eigen::Vector4f(0, 0, 0, -1.0f), Eigen::Vector3f::Zero()
+                );
+            }
             for (auto& worker: workers) {
                 if (worker.joinable()) {
                     worker.join();
@@ -148,10 +205,13 @@ void RasterizerRenderer::render(const Scene& scene)
         }
     }
 
-    time_point end_time           = steady_clock::now();
-    duration   rendering_duration = end_time - begin_time;
+    auto end_time           = steady_clock::now();
+    auto rendering_duration = std::chrono::duration<double, std::milli>(end_time - begin_time);
 
-    this->logger->info("rendering takes {:.6f} seconds", rendering_duration.count());
+    this->logger->info(
+        "Rasterizer rendering finished (mode: {}) in {:.3f} ms ({:.6f} s)", mode_name,
+        rendering_duration.count(), rendering_duration.count() / 1000.0
+    );
 
     for (long unsigned int i = 0; i < Context::frame_buffer.depth_buffer.size(); i++) {
         rendering_res.push_back(
@@ -168,69 +228,118 @@ void RasterizerRenderer::render(const Scene& scene)
 
 void VertexProcessor::input_vertices(const Vector4f& positions, const Vector3f& normals)
 {
-    std::unique_lock<std::mutex> lock(queue_mutex);
-    VertexShaderPayload          payload;
-    payload.world_position = positions;
-    payload.normal         = normals;
-    vertex_queue.push(payload);
+    VertexShaderPayload payload;
+    payload.world_position  = positions;
+    payload.viewport_position = Eigen::Vector4f::Zero();
+    payload.normal          = normals;
+    if (positions.w() == -1.0f) {
+        payload.terminate = true;
+    } else {
+        payload.vertex_index = Context::vertex_input_index.fetch_add(1);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex);
+        vertex_queue.push(payload);
+    }
+
+    if (payload.terminate) {
+        queue_cv.notify_all();
+    } else {
+        queue_cv.notify_one();
+    }
 }
 
 void VertexProcessor::worker_thread()
 {
     while (true) {
-        std::unique_lock<std::mutex> lock(queue_mutex);
-
-        if (vertex_queue.empty()) {
-            if (Context::vertex_finish) {
-                return;
-            }
-            lock.unlock();
-            std::this_thread::yield();
-            continue;
+        VertexShaderPayload payload;
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex);
+            queue_cv.wait(lock, [&] { return !vertex_queue.empty(); });
+            payload = vertex_queue.front();
+            vertex_queue.pop();
         }
 
-        VertexShaderPayload payload = vertex_queue.front();
-        vertex_queue.pop();
-
-        if (payload.world_position.w() == -1.0f) {
-            Context::vertex_finish = true;
+        if (payload.terminate) {
+            queue_cv.notify_all();
             return;
         }
 
         VertexShaderPayload output_payload = vertex_shader_ptr(payload);
+        bool                triangle_pushed = false;
 
         {
-            std::unique_lock<std::mutex> output_lock(Context::vertex_queue_mutex);
-            Context::vertex_shader_output_queue.push(output_payload);
+            std::lock_guard<std::mutex> output_lock(Context::vertex_queue_mutex);
+            if (payload.vertex_index < Context::vertex_shader_output_buffer.size()) {
+                Context::vertex_shader_output_buffer[payload.vertex_index] = output_payload;
+                Context::vertex_output_ready[payload.vertex_index]          = 1;
+
+                std::size_t triangle_index = payload.vertex_index / 3;
+                if (
+                    triangle_index < Context::triangle_enqueued.size()
+                    && !Context::triangle_enqueued[triangle_index]
+                ) {
+                    std::size_t base = triangle_index * 3;
+                    if (
+                        base + 2 < Context::vertex_shader_output_buffer.size()
+                        && Context::vertex_output_ready[base]
+                        && Context::vertex_output_ready[base + 1]
+                        && Context::vertex_output_ready[base + 2]
+                    ) {
+                        for (std::size_t i = 0; i < 3; ++i) {
+                            Context::vertex_shader_output_queue.push(
+                                Context::vertex_shader_output_buffer[base + i]
+                            );
+                        }
+                        Context::triangle_enqueued[triangle_index] = 1;
+                        triangle_pushed                              = true;
+                    }
+                }
+            }
+        }
+
+        if (triangle_pushed) {
+            Context::vertex_output_cv.notify_all();
+        }
+
+        std::size_t processed = ++Context::vertex_processed_count;
+        if (processed == Context::vertex_total_count) {
+            Context::vertex_finish = true;
+            Context::vertex_output_cv.notify_all();
         }
     }
 }
 
 void FragmentProcessor::worker_thread()
 {
-    while (!Context::fragment_finish) {
-        FragmentShaderPayload fragment;
+    while (true) {
+        std::vector<FragmentShaderPayload> fragments;
         {
-            if (Context::rasterizer_finish && Context::rasterizer_output_queue.empty()) {
-                Context::fragment_finish = true;
-                return;
-            }
-            if (Context::rasterizer_output_queue.empty()) {
-                continue;
-            }
             std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
+            Context::rasterizer_output_cv.wait(lock, [&] {
+                return !Context::rasterizer_output_queue.empty() || Context::rasterizer_finish;
+            });
             if (Context::rasterizer_output_queue.empty()) {
+                if (Context::rasterizer_finish) {
+                    Context::fragment_finish = true;
+                    return;
+                }
                 continue;
             }
-            fragment = Context::rasterizer_output_queue.front();
+            fragments = std::move(Context::rasterizer_output_queue.front());
             Context::rasterizer_output_queue.pop();
         }
-        int index = (Uniforms::height - 1 - fragment.y) * Uniforms::width + fragment.x;
-        if (fragment.depth > Context::frame_buffer.depth_buffer[index]) {
-            continue;
+
+        for (auto& fragment: fragments) {
+            int index = (Uniforms::height - 1 - fragment.y) * Uniforms::width + fragment.x;
+            if (fragment.depth > Context::frame_buffer.depth_buffer[index]) {
+                continue;
+            }
+            fragment.color = fragment_shader_ptr(
+                fragment, Uniforms::material, Uniforms::lights, Uniforms::camera
+            );
+            Context::frame_buffer.set_pixel(index, fragment.depth, fragment.color);
         }
-        fragment.color =
-            fragment_shader_ptr(fragment, Uniforms::material, Uniforms::lights, Uniforms::camera);
-        Context::frame_buffer.set_pixel(index, fragment.depth, fragment.color);
     }
 }

--- a/src1/render/rasterizer_renderer.h
+++ b/src1/render/rasterizer_renderer.h
@@ -3,6 +3,7 @@
 
 #include <list>
 #include <queue>
+#include <condition_variable>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -53,6 +54,8 @@ private:
     std::queue<VertexShaderPayload> vertex_queue;
     /*! \~chinese 保护顶点队列的互斥锁 */
     std::mutex                      queue_mutex;
+    /*! \~chinese 顶点输入队列的条件变量 */
+    std::condition_variable         queue_cv;
 };
 
 /*!

--- a/src1/render/render_engine.cpp
+++ b/src1/render/render_engine.cpp
@@ -1,15 +1,55 @@
 #include "render_engine.h"
 
+#include <algorithm>
+
 Eigen::Vector3f RenderEngine::background_color(RGB_COLOR(100, 100, 100));
 
-RenderEngine::RenderEngine()
+RenderEngine::RenderEngine() :
+    width(0.0f),
+    height(0.0f),
+    n_threads(4),
+    rasterizer_mode(PipelineMode::Parallel),
+    rasterizer_parallel_threads(2)
 {
     // unique pointer to Rasterizer Renderer
-    rasterizer_render = std::make_unique<RasterizerRenderer>(*this, 2, 2, 2);
+    rasterizer_render = std::make_unique<RasterizerRenderer>(
+        *this, rasterizer_parallel_threads, rasterizer_parallel_threads, rasterizer_parallel_threads
+    );
     // unique pointer to Whitted Style Renderer
     whitted_render = std::make_unique<WhittedRenderer>(*this);
-    // default setting of number of threads(if use multi-threads edition)
-    n_threads = 4;
+
+    set_rasterizer_pipeline_mode(rasterizer_mode);
+    set_rasterizer_parallel_thread_count(rasterizer_parallel_threads);
+}
+
+void RenderEngine::set_rasterizer_pipeline_mode(PipelineMode mode)
+{
+    rasterizer_mode = mode;
+    if (rasterizer_render) {
+        rasterizer_render->set_pipeline_mode(mode);
+    }
+}
+
+PipelineMode RenderEngine::get_rasterizer_pipeline_mode() const
+{
+    return rasterizer_mode;
+}
+
+void RenderEngine::set_rasterizer_parallel_thread_count(int threads)
+{
+    int clamped = std::max(1, threads);
+    rasterizer_parallel_threads = clamped;
+    if (rasterizer_render) {
+        rasterizer_render->set_parallel_thread_count(clamped);
+    }
+}
+
+int RenderEngine::get_rasterizer_parallel_thread_count() const
+{
+    if (rasterizer_render) {
+        return rasterizer_render->parallel_thread_count();
+    }
+    return rasterizer_parallel_threads;
 }
 
 // choose render type

--- a/src1/render/render_engine.h
+++ b/src1/render/render_engine.h
@@ -39,6 +39,17 @@ enum class RendererType
 /*!
  * \ingroup rendering
  * \~chinese
+ * \brief 光栅化流水线的运行模式。
+ */
+enum class PipelineMode
+{
+    Serial,
+    Parallel
+};
+
+/*!
+ * \ingroup rendering
+ * \~chinese
  * \brief 离线渲染的执行入口
  */
 class RenderEngine
@@ -65,6 +76,30 @@ public:
      * \param type 渲染器类型
      */
     void render(Scene& scene, RendererType type);
+
+    /*!
+     * \~chinese
+     * \brief 设置光栅化流水线的运行模式
+     */
+    void set_rasterizer_pipeline_mode(PipelineMode mode);
+
+    /*!
+     * \~chinese
+     * \brief 获取当前光栅化流水线的运行模式
+     */
+    PipelineMode get_rasterizer_pipeline_mode() const;
+
+    /*!
+     * \~chinese
+     * \brief 设置并行流水线下每个阶段的线程数
+     */
+    void set_rasterizer_parallel_thread_count(int threads);
+
+    /*!
+     * \~chinese
+     * \brief 获取并行流水线下每个阶段的线程数
+     */
+    int get_rasterizer_parallel_thread_count() const;
     /*! \~chinese 渲染结果预览的背景颜色 */
     static Eigen::Vector3f background_color;
 
@@ -72,6 +107,10 @@ public:
     std::unique_ptr<RasterizerRenderer> rasterizer_render;
     /*! \~chinese whitted style渲染器 */
     std::unique_ptr<WhittedRenderer> whitted_render;
+
+private:
+    PipelineMode rasterizer_mode;
+    int          rasterizer_parallel_threads;
 };
 
 /*!
@@ -91,11 +130,31 @@ public:
     /*! \~chinese 光栅化渲染器的渲染调用接口*/
     void render(const Scene& scene);
 
+    /*!
+     * \~chinese
+     * \brief 配置流水线模式。
+     */
+    void set_pipeline_mode(PipelineMode mode);
+
+    /*!
+     * \~chinese
+     * \brief 设置并行模式下的线程数
+     */
+    void set_parallel_thread_count(int count);
+
+    /*!
+     * \~chinese
+     * \brief 获取并行模式下的线程数
+     */
+    int parallel_thread_count() const;
+
     float& width;
     float& height;
     int    n_vertex_threads;
     int    n_rasterizer_threads;
     int    n_fragment_threads;
+
+    PipelineMode pipeline_mode;
 
     // initialize vertex processor
     VertexProcessor vertex_processor;

--- a/src1/render/shader.cpp
+++ b/src1/render/shader.cpp
@@ -16,9 +16,8 @@ VertexShaderPayload vertex_shader(const VertexShaderPayload& payload)
 {
     VertexShaderPayload output_payload = payload;
 
-    Eigen::Matrix4f model_matrix = Uniforms::inv_trans_M.inverse().transpose();
-    Eigen::Vector4f model_pos    = payload.world_position;
-    Eigen::Vector4f world_pos    = model_matrix * model_pos;
+    Eigen::Vector4f model_pos = payload.world_position;
+    Eigen::Vector4f world_pos = Uniforms::model * model_pos;
     output_payload.world_position = world_pos;
 
     Eigen::Vector4f clip_pos = Uniforms::MVP * model_pos;

--- a/src1/ui/toolbar.cpp
+++ b/src1/ui/toolbar.cpp
@@ -348,7 +348,8 @@ void Toolbar::model_mode(Scene& scene)
     }
 }
 
-const char* renderer_names[] = {"Rasterizer Renderer", "Whitted-Style Ray-Tracer"};
+const char* renderer_names[]    = {"Rasterizer Renderer", "Whitted-Style Ray-Tracer"};
+const char* pipeline_mode_names[] = {"Serial Pipeline", "Parallel Pipeline"};
 
 void Toolbar::render_mode(Scene& scene)
 {
@@ -373,8 +374,22 @@ void Toolbar::render_mode(Scene& scene)
         default: break;
         }
         if (current_renderer == RendererType::RASTERIZER) {
-            ImGui::SetNextItemWidth(0.5f * ImGui::CalcItemWidth());
-            ImGui::InputInt("Number of Threads", &render_engine.n_threads);
+            int pipeline_mode_index =
+                render_engine.get_rasterizer_pipeline_mode() == PipelineMode::Serial ? 0 : 1;
+            if (ImGui::Combo("Pipeline Mode", &pipeline_mode_index, pipeline_mode_names, 2)) {
+                PipelineMode selected_mode =
+                    pipeline_mode_index == 0 ? PipelineMode::Serial : PipelineMode::Parallel;
+                render_engine.set_rasterizer_pipeline_mode(selected_mode);
+            }
+
+            if (pipeline_mode_index == 1) {
+                int parallel_threads = render_engine.get_rasterizer_parallel_thread_count();
+                ImGui::SetNextItemWidth(0.5f * ImGui::CalcItemWidth());
+                if (ImGui::InputInt("Number of Threads", &parallel_threads)) {
+                    render_engine.set_rasterizer_parallel_thread_count(parallel_threads);
+                    parallel_threads = render_engine.get_rasterizer_parallel_thread_count();
+                }
+            }
         }
         if (current_renderer == RendererType::WHITTED_STYLE) {
             ImGui::Checkbox("Use BVH for Acceleration", &render_engine.whitted_render->use_bvh);


### PR DESCRIPTION
## Summary
- batch triangle results before enqueuing to the rasterizer and fragment stages to reduce synchronization overhead
- improve vertex-stage ordering with per-triangle readiness tracking and add a model matrix uniform for stable shading
- increase render time logging precision to milliseconds for clearer performance comparisons

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_b_68d7a901e4dc833397caac040027f432