### PR TITLE
Improve rasterizer pipeline throughput and stabilize debug mode

### DIFF
--- a/src1/render/graphics_interface.h
+++ b/src1/render/graphics_interface.h
@@ -4,6 +4,9 @@
 #include <memory>
 #include <functional>
 #include <queue>
+#include <condition_variable>
+#include <atomic>
+#include <cstddef>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -31,6 +34,10 @@ struct VertexShaderPayload
     Eigen::Vector4f viewport_position;
     /*! \~chinese 顶点法线 */
     Eigen::Vector3f normal;
+    /*! \~chinese 顶点在输入序列中的编号 */
+    std::size_t     vertex_index = 0;
+    /*! \~chinese 是否为终止任务 */
+    bool            terminate    = false;
 };
 
 /*!
@@ -217,18 +224,41 @@ struct Context
     static std::mutex rasterizer_queue_mutex;
     /*! \~chinese vertex shader的输出队列 */
     static std::queue<VertexShaderPayload> vertex_shader_output_queue;
-    /*! \~chinese rasterizer的输出队列 */
-    static std::queue<FragmentShaderPayload> rasterizer_output_queue;
+    /*! \~chinese 顶点着色器输出可用时的条件变量 */
+    static std::condition_variable vertex_output_cv;
+    /*! \~chinese 光栅化输出可用时的条件变量 */
+    static std::condition_variable rasterizer_output_cv;
+
+    /*! \~chinese 当前光栅化线程获取的三角形索引 */
+    static std::atomic<std::size_t> rasterizer_triangle_index;
+    /*! \~chinese 本批次待处理的三角形总数 */
+    static std::size_t              rasterizer_triangle_count;
 
     /*! \~chinese 标识顶点着色器是否全部执行完毕。 */
-    volatile static bool vertex_finish;
+    static std::atomic<bool> vertex_finish;
     /*! \~chinese 标识三角形是否全部被光栅化。 */
-    volatile static bool rasterizer_finish;
+    static std::atomic<bool> rasterizer_finish;
     /*! \~chinese 标识片元着色器是否全部执行完毕。 */
-    volatile static bool fragment_finish;
+    static std::atomic<bool> fragment_finish;
 
     /*! \~chinese 渲染使用的 frame buffer 。 */
     static FrameBuffer frame_buffer;
+
+    /*! \~chinese 顶点输入时的顺序计数器 */
+    static std::atomic<std::size_t> vertex_input_index;
+    /*! \~chinese 顶点处理完成的数量 */
+    static std::atomic<std::size_t> vertex_processed_count;
+    /*! \~chinese 顶点总数 */
+    static std::size_t              vertex_total_count;
+    /*! \~chinese 已按序写入输出队列的下标 */
+    static std::size_t              vertex_flush_index;
+    /*! \~chinese 顶点着色器输出的缓存 */
+    static std::vector<VertexShaderPayload> vertex_shader_output_buffer;
+    /*! \~chinese 顶点着色器输出是否就绪 */
+    static std::vector<char> vertex_output_ready;
+
+    /*! \~chinese 片元批次队列 */
+    static std::queue<std::vector<FragmentShaderPayload>> fragment_batch_queue;
 };
 
 #endif // DANDELION_RENDER_GRAPHICS_INTERFACE_H

--- a/src1/render/rasterizer.cpp
+++ b/src1/render/rasterizer.cpp
@@ -24,29 +24,19 @@ using std::tuple;
 void Rasterizer::worker_thread()
 {
     while (true) {
-        VertexShaderPayload payloads[3];
-        {
-            std::unique_lock<std::mutex> lock(Context::vertex_queue_mutex);
-
-            if (Context::vertex_shader_output_queue.size() < 3) {
-                if (Context::vertex_finish) {
-                    Context::rasterizer_finish = true;
-                    return;
-                }
-                continue;
-            }
-
-            for (int i = 0; i < 3; ++i) {
-                payloads[i] = Context::vertex_shader_output_queue.front();
-                Context::vertex_shader_output_queue.pop();
-            }
+        std::size_t triangle_index = Context::rasterizer_triangle_index.fetch_add(1);
+        if (triangle_index >= Context::rasterizer_triangle_count) {
+            return;
         }
 
-        Triangle triangle;
+        std::size_t base_index = triangle_index * 3;
+        Triangle    triangle;
+
         for (int i = 0; i < 3; ++i) {
-            triangle.world_pos[i]    = payloads[i].world_position;
-            triangle.viewport_pos[i] = payloads[i].viewport_position;
-            triangle.normal[i]       = payloads[i].normal;
+            const auto& payload = Context::vertex_shader_output_buffer[base_index + i];
+            triangle.world_pos[i]    = payload.world_position;
+            triangle.viewport_pos[i] = payload.viewport_position;
+            triangle.normal[i]       = payload.normal;
         }
 
         rasterize_triangle(triangle);
@@ -135,6 +125,10 @@ void Rasterizer::rasterize_triangle(Triangle& t)
     Vector3f normal1    = t.normal[1];
     Vector3f normal2    = t.normal[2];
 
+    std::vector<FragmentShaderPayload> fragment_batch;
+    fragment_batch.reserve(static_cast<std::size_t>(std::max(0, x1 - x0 + 1))
+                           * static_cast<std::size_t>(std::max(0, y1 - y0 + 1)));
+
     for (int x = x0; x <= x1; ++x) {
         for (int y = y0; y <= y1; ++y) {
             if (!inside_triangle(x, y, v)) {
@@ -173,10 +167,13 @@ void Rasterizer::rasterize_triangle(Triangle& t)
             payload.y     = y;
             payload.depth = depth;
 
-            {
-                std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
-                Context::rasterizer_output_queue.push(payload);
-            }
+            fragment_batch.push_back(payload);
         }
+    }
+
+    if (!fragment_batch.empty()) {
+        std::lock_guard<std::mutex> lock(Context::rasterizer_queue_mutex);
+        Context::fragment_batch_queue.emplace(std::move(fragment_batch));
+        Context::rasterizer_output_cv.notify_all();
     }
 }

--- a/src1/render/rasterizer_renderer.cpp
+++ b/src1/render/rasterizer_renderer.cpp
@@ -4,6 +4,9 @@
 #include <thread>
 #include <chrono>
 #include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <algorithm>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -14,8 +17,6 @@
 
 using std::chrono::steady_clock;
 using std::size_t;
-using duration   = std::chrono::duration<float>;
-using time_point = std::chrono::time_point<steady_clock, duration>;
 using Eigen::Vector3f;
 using Eigen::Vector4f;
 
@@ -37,11 +38,22 @@ Camera&           Uniforms::camera   = ini_camera;
 std::mutex                        Context::vertex_queue_mutex;
 std::mutex                        Context::rasterizer_queue_mutex;
 std::queue<VertexShaderPayload>   Context::vertex_shader_output_queue;
-std::queue<FragmentShaderPayload> Context::rasterizer_output_queue;
+std::condition_variable           Context::vertex_output_cv;
+std::condition_variable           Context::rasterizer_output_cv;
+std::atomic<std::size_t>          Context::rasterizer_triangle_index{0};
+std::size_t                       Context::rasterizer_triangle_count = 0;
 
-volatile bool Context::vertex_finish     = false;
-volatile bool Context::rasterizer_finish = false;
-volatile bool Context::fragment_finish   = false;
+std::atomic<bool> Context::vertex_finish{false};
+std::atomic<bool> Context::rasterizer_finish{false};
+std::atomic<bool> Context::fragment_finish{false};
+
+std::atomic<std::size_t>           Context::vertex_input_index{0};
+std::atomic<std::size_t>           Context::vertex_processed_count{0};
+std::size_t                        Context::vertex_total_count = 0;
+std::size_t                        Context::vertex_flush_index = 0;
+std::vector<VertexShaderPayload>   Context::vertex_shader_output_buffer;
+std::vector<char>                  Context::vertex_output_ready;
+std::queue<std::vector<FragmentShaderPayload>> Context::fragment_batch_queue;
 
 FrameBuffer Context::frame_buffer(Uniforms::width, Uniforms::height);
 
@@ -61,176 +73,268 @@ RasterizerRenderer::RasterizerRenderer(
 ) :
     width(engine.width), height(engine.height), n_vertex_threads(num_vertex_threads),
     n_rasterizer_threads(num_rasterizer_threads), n_fragment_threads(num_fragment_threads),
+    pipeline_mode(PipelineMode::Parallel),
     vertex_processor(), rasterizer(), fragment_processor(), rendering_res(engine.rendering_res)
 {
     logger = get_logger("Rasterizer Renderer");
 }
 
+void RasterizerRenderer::set_pipeline_mode(PipelineMode mode)
+{
+    pipeline_mode = mode;
+}
+
+void RasterizerRenderer::set_parallel_thread_count(int count)
+{
+    int clamped          = std::max(1, count);
+    n_vertex_threads     = clamped;
+    n_rasterizer_threads = clamped;
+    n_fragment_threads   = clamped;
+}
+
+int RasterizerRenderer::parallel_thread_count() const
+{
+    return n_vertex_threads;
+}
+
 // 光栅化渲染器的渲染调用接口
 void RasterizerRenderer::render(const Scene& scene)
 {
-    Uniforms::width       = static_cast<int>(width);
-    Uniforms::height      = static_cast<int>(height);
+    Uniforms::width  = static_cast<int>(width);
+    Uniforms::height = static_cast<int>(height);
     Context::frame_buffer = FrameBuffer(Uniforms::width, Uniforms::height);
-    // clear Color Buffer & Depth Buffer & rendering_res
     Context::frame_buffer.clear(BufferType::Color | BufferType::Depth);
-    this->rendering_res.clear();
-    // run time statistics
-    time_point begin_time                  = steady_clock::now();
-    Camera     cam                         = scene.camera;
+    rendering_res.clear();
+
+    auto begin_time = steady_clock::now();
+
     vertex_processor.vertex_shader_ptr     = vertex_shader;
     fragment_processor.fragment_shader_ptr = phong_fragment_shader;
+
+    int vertex_threads     = pipeline_mode == PipelineMode::Serial ? 1 : n_vertex_threads;
+    int rasterizer_threads = pipeline_mode == PipelineMode::Serial ? 1 : n_rasterizer_threads;
+    int fragment_threads   = pipeline_mode == PipelineMode::Serial ? 1 : n_fragment_threads;
+
+    const char* mode_name = pipeline_mode == PipelineMode::Serial ? "Serial" : "Parallel";
+    logger->info(
+        "Rasterizer rendering started (mode: {}, vertex: {}, rasterizer: {}, fragment: {})",
+        mode_name, vertex_threads, rasterizer_threads, fragment_threads
+    );
+
+    Camera cam = scene.camera;
+
     for (const auto& group: scene.groups) {
         for (const auto& object: group->objects) {
-            Context::vertex_finish     = false;
-            Context::rasterizer_finish = false;
-            Context::fragment_finish   = false;
+            const auto& vertices = object->mesh.vertices.data;
+            const auto& normals  = object->mesh.normals.data;
+            const auto& faces    = object->mesh.faces.data;
 
-            {
-                std::lock_guard<std::mutex> lock(Context::vertex_queue_mutex);
-                while (!Context::vertex_shader_output_queue.empty()) {
-                    Context::vertex_shader_output_queue.pop();
-                }
-            }
-            {
-                std::lock_guard<std::mutex> lock(Context::rasterizer_queue_mutex);
-                while (!Context::rasterizer_output_queue.empty()) {
-                    Context::rasterizer_output_queue.pop();
-                }
+            std::size_t num_indices   = faces.size();
+            std::size_t triangle_count = num_indices / 3;
+
+            if (num_indices == 0 || triangle_count == 0) {
+                continue;
             }
 
-            std::vector<std::thread> workers;
-            for (int i = 0; i < n_vertex_threads; ++i) {
-                workers.emplace_back(&VertexProcessor::worker_thread, &vertex_processor);
-            }
-            for (int i = 0; i < n_rasterizer_threads; ++i) {
-                workers.emplace_back(&Rasterizer::worker_thread, &rasterizer);
-            }
-            for (int i = 0; i < n_fragment_threads; ++i) {
-                workers.emplace_back(&FragmentProcessor::worker_thread, &fragment_processor);
-            }
-
-            // set Uniforms for vertex shader
             Uniforms::MVP         = cam.projection() * cam.view() * object->model();
             Uniforms::inv_trans_M = object->model().inverse().transpose();
-            Uniforms::width       = static_cast<int>(this->width);
-            Uniforms::height      = static_cast<int>(this->height);
+            Uniforms::width       = static_cast<int>(width);
+            Uniforms::height      = static_cast<int>(height);
             Uniforms::material    = object->mesh.material;
             Uniforms::lights      = scene.lights;
-            Uniforms::camera      = scene.camera;
+            Uniforms::camera      = cam;
 
-            // input object->mesh's vertices & faces & normals data
-            const std::vector<float>&        vertices  = object->mesh.vertices.data;
-            const std::vector<unsigned int>& faces     = object->mesh.faces.data;
-            const std::vector<float>&        normals   = object->mesh.normals.data;
-            size_t                           num_faces = faces.size();
+            std::vector<VertexShaderPayload> vertex_outputs(num_indices);
+            Context::vertex_finish.store(false, std::memory_order_release);
 
-            // process vertices
-            for (size_t i = 0; i < num_faces; i += 3) {
-                for (size_t j = 0; j < 3; j++) {
-                    size_t idx = faces[i + j];
-                    vertex_processor.input_vertices(
-                        Vector4f(
-                            vertices[3 * idx], vertices[3 * idx + 1], vertices[3 * idx + 2], 1.0f
-                        ),
-                        Vector3f(normals[3 * idx], normals[3 * idx + 1], normals[3 * idx + 2])
+            auto process_vertex = [&](int thread_id) {
+                for (std::size_t idx = thread_id; idx < num_indices; idx += vertex_threads) {
+                    unsigned int vertex_id = faces[idx];
+                    VertexShaderPayload payload;
+                    payload.world_position = Vector4f(
+                        vertices[3 * vertex_id], vertices[3 * vertex_id + 1],
+                        vertices[3 * vertex_id + 2], 1.0f
                     );
+                    payload.viewport_position = Vector4f::Zero();
+                    payload.normal             = Vector3f(
+                        normals[3 * vertex_id], normals[3 * vertex_id + 1], normals[3 * vertex_id + 2]
+                    );
+                    VertexShaderPayload transformed = vertex_processor.vertex_shader_ptr(payload);
+                    vertex_outputs[idx]              = transformed;
                 }
-            }
-            vertex_processor.input_vertices(
-                Eigen::Vector4f(0, 0, 0, -1.0f), Eigen::Vector3f::Zero()
-            );
-            for (auto& worker: workers) {
-                if (worker.joinable()) {
+            };
+
+            if (vertex_threads == 1) {
+                process_vertex(0);
+            } else {
+                std::vector<std::thread> vertex_workers;
+                vertex_workers.reserve(vertex_threads);
+                for (int i = 0; i < vertex_threads; ++i) {
+                    vertex_workers.emplace_back(process_vertex, i);
+                }
+                for (auto& worker: vertex_workers) {
                     worker.join();
                 }
             }
+
+            Context::vertex_shader_output_buffer = std::move(vertex_outputs);
+            Context::vertex_total_count           = num_indices;
+            Context::vertex_finish.store(true, std::memory_order_release);
+
+            Context::rasterizer_triangle_index.store(0);
+            Context::rasterizer_triangle_count = triangle_count;
+            Context::rasterizer_finish.store(false, std::memory_order_release);
+            Context::fragment_finish.store(false, std::memory_order_release);
+
+            {
+                std::lock_guard<std::mutex> lock(Context::rasterizer_queue_mutex);
+                Context::fragment_batch_queue = {};
+            }
+
+            std::vector<std::thread> fragment_workers;
+            fragment_workers.reserve(fragment_threads);
+            for (int i = 0; i < fragment_threads; ++i) {
+                fragment_workers.emplace_back(&FragmentProcessor::worker_thread, &fragment_processor);
+            }
+
+            std::vector<std::thread> raster_workers;
+            raster_workers.reserve(rasterizer_threads);
+            for (int i = 0; i < rasterizer_threads; ++i) {
+                raster_workers.emplace_back(&Rasterizer::worker_thread, &rasterizer);
+            }
+
+            for (auto& worker: raster_workers) {
+                worker.join();
+            }
+
+            Context::rasterizer_finish.store(true, std::memory_order_release);
+            Context::rasterizer_output_cv.notify_all();
+
+            for (auto& worker: fragment_workers) {
+                worker.join();
+            }
+
+            Context::fragment_finish.store(true, std::memory_order_release);
+            Context::vertex_shader_output_buffer.clear();
         }
     }
 
-    time_point end_time           = steady_clock::now();
-    duration   rendering_duration = end_time - begin_time;
+    auto end_time = steady_clock::now();
+    double rendering_duration = std::chrono::duration<double>(end_time - begin_time).count();
 
-    this->logger->info("rendering takes {:.6f} seconds", rendering_duration.count());
+    logger->info(
+        "Rasterizer rendering finished (mode: {}) in {:.6f} seconds", mode_name,
+        rendering_duration
+    );
 
-    for (long unsigned int i = 0; i < Context::frame_buffer.depth_buffer.size(); i++) {
-        rendering_res.push_back(
-            static_cast<unsigned char>(Context::frame_buffer.color_buffer[i].x())
-        );
-        rendering_res.push_back(
-            static_cast<unsigned char>(Context::frame_buffer.color_buffer[i].y())
-        );
-        rendering_res.push_back(
-            static_cast<unsigned char>(Context::frame_buffer.color_buffer[i].z())
-        );
+    for (std::size_t i = 0; i < Context::frame_buffer.depth_buffer.size(); ++i) {
+        rendering_res.push_back(static_cast<unsigned char>(Context::frame_buffer.color_buffer[i].x()));
+        rendering_res.push_back(static_cast<unsigned char>(Context::frame_buffer.color_buffer[i].y()));
+        rendering_res.push_back(static_cast<unsigned char>(Context::frame_buffer.color_buffer[i].z()));
     }
 }
 
 void VertexProcessor::input_vertices(const Vector4f& positions, const Vector3f& normals)
 {
-    std::unique_lock<std::mutex> lock(queue_mutex);
-    VertexShaderPayload          payload;
-    payload.world_position = positions;
-    payload.normal         = normals;
-    vertex_queue.push(payload);
+    VertexShaderPayload payload;
+    payload.world_position  = positions;
+    payload.viewport_position = Eigen::Vector4f::Zero();
+    payload.normal          = normals;
+    if (positions.w() == -1.0f) {
+        payload.terminate = true;
+    } else {
+        payload.vertex_index = Context::vertex_input_index.fetch_add(1);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex);
+        vertex_queue.push(payload);
+    }
+
+    if (payload.terminate) {
+        queue_cv.notify_all();
+    } else {
+        queue_cv.notify_one();
+    }
 }
 
 void VertexProcessor::worker_thread()
 {
     while (true) {
-        std::unique_lock<std::mutex> lock(queue_mutex);
-
-        if (vertex_queue.empty()) {
-            if (Context::vertex_finish) {
-                return;
-            }
-            lock.unlock();
-            std::this_thread::yield();
-            continue;
+        VertexShaderPayload payload;
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex);
+            queue_cv.wait(lock, [&] { return !vertex_queue.empty(); });
+            payload = vertex_queue.front();
+            vertex_queue.pop();
         }
 
-        VertexShaderPayload payload = vertex_queue.front();
-        vertex_queue.pop();
-
-        if (payload.world_position.w() == -1.0f) {
-            Context::vertex_finish = true;
+        if (payload.terminate) {
+            queue_cv.notify_all();
             return;
         }
 
         VertexShaderPayload output_payload = vertex_shader_ptr(payload);
 
         {
-            std::unique_lock<std::mutex> output_lock(Context::vertex_queue_mutex);
-            Context::vertex_shader_output_queue.push(output_payload);
+            std::lock_guard<std::mutex> output_lock(Context::vertex_queue_mutex);
+            if (payload.vertex_index < Context::vertex_shader_output_buffer.size()) {
+                Context::vertex_shader_output_buffer[payload.vertex_index] = output_payload;
+                Context::vertex_output_ready[payload.vertex_index]          = 1;
+                while (
+                    Context::vertex_flush_index < Context::vertex_total_count
+                    && Context::vertex_output_ready[Context::vertex_flush_index]
+                ) {
+                    Context::vertex_shader_output_queue.push(
+                        Context::vertex_shader_output_buffer[Context::vertex_flush_index]
+                    );
+                    ++Context::vertex_flush_index;
+                }
+            }
+        }
+
+        Context::vertex_output_cv.notify_all();
+
+        std::size_t processed = ++Context::vertex_processed_count;
+        if (processed == Context::vertex_total_count) {
+            Context::vertex_finish.store(true, std::memory_order_release);
+            Context::vertex_output_cv.notify_all();
         }
     }
 }
 
 void FragmentProcessor::worker_thread()
 {
-    while (!Context::fragment_finish) {
-        FragmentShaderPayload fragment;
+    while (true) {
+        std::vector<FragmentShaderPayload> batch;
         {
-            if (Context::rasterizer_finish && Context::rasterizer_output_queue.empty()) {
-                Context::fragment_finish = true;
-                return;
-            }
-            if (Context::rasterizer_output_queue.empty()) {
-                continue;
-            }
             std::unique_lock<std::mutex> lock(Context::rasterizer_queue_mutex);
-            if (Context::rasterizer_output_queue.empty()) {
+            Context::rasterizer_output_cv.wait(lock, [] {
+                return !Context::fragment_batch_queue.empty()
+                       || Context::rasterizer_finish.load(std::memory_order_acquire);
+            });
+
+            if (Context::fragment_batch_queue.empty()) {
+                if (Context::rasterizer_finish.load(std::memory_order_acquire)) {
+                    Context::fragment_finish.store(true, std::memory_order_release);
+                    return;
+                }
                 continue;
             }
-            fragment = Context::rasterizer_output_queue.front();
-            Context::rasterizer_output_queue.pop();
+
+            batch = std::move(Context::fragment_batch_queue.front());
+            Context::fragment_batch_queue.pop();
         }
-        int index = (Uniforms::height - 1 - fragment.y) * Uniforms::width + fragment.x;
-        if (fragment.depth > Context::frame_buffer.depth_buffer[index]) {
-            continue;
+
+        for (const auto& fragment: batch) {
+            int index = (Uniforms::height - 1 - fragment.y) * Uniforms::width + fragment.x;
+            if (fragment.depth > Context::frame_buffer.depth_buffer[index]) {
+                continue;
+            }
+            Eigen::Vector3f color = fragment_shader_ptr(
+                fragment, Uniforms::material, Uniforms::lights, Uniforms::camera
+            );
+            Context::frame_buffer.set_pixel(index, fragment.depth, color);
         }
-        fragment.color =
-            fragment_shader_ptr(fragment, Uniforms::material, Uniforms::lights, Uniforms::camera);
-        Context::frame_buffer.set_pixel(index, fragment.depth, fragment.color);
     }
 }

--- a/src1/render/rasterizer_renderer.h
+++ b/src1/render/rasterizer_renderer.h
@@ -3,6 +3,7 @@
 
 #include <list>
 #include <queue>
+#include <condition_variable>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -53,6 +54,8 @@ private:
     std::queue<VertexShaderPayload> vertex_queue;
     /*! \~chinese 保护顶点队列的互斥锁 */
     std::mutex                      queue_mutex;
+    /*! \~chinese 顶点输入队列的条件变量 */
+    std::condition_variable         queue_cv;
 };
 
 /*!

--- a/src1/render/render_engine.cpp
+++ b/src1/render/render_engine.cpp
@@ -1,15 +1,55 @@
 #include "render_engine.h"
 
+#include <algorithm>
+
 Eigen::Vector3f RenderEngine::background_color(RGB_COLOR(100, 100, 100));
 
-RenderEngine::RenderEngine()
+RenderEngine::RenderEngine() :
+    width(0.0f),
+    height(0.0f),
+    n_threads(4),
+    rasterizer_mode(PipelineMode::Parallel),
+    rasterizer_parallel_threads(2)
 {
     // unique pointer to Rasterizer Renderer
-    rasterizer_render = std::make_unique<RasterizerRenderer>(*this, 2, 2, 2);
+    rasterizer_render = std::make_unique<RasterizerRenderer>(
+        *this, rasterizer_parallel_threads, rasterizer_parallel_threads, rasterizer_parallel_threads
+    );
     // unique pointer to Whitted Style Renderer
     whitted_render = std::make_unique<WhittedRenderer>(*this);
-    // default setting of number of threads(if use multi-threads edition)
-    n_threads = 4;
+
+    set_rasterizer_pipeline_mode(rasterizer_mode);
+    set_rasterizer_parallel_thread_count(rasterizer_parallel_threads);
+}
+
+void RenderEngine::set_rasterizer_pipeline_mode(PipelineMode mode)
+{
+    rasterizer_mode = mode;
+    if (rasterizer_render) {
+        rasterizer_render->set_pipeline_mode(mode);
+    }
+}
+
+PipelineMode RenderEngine::get_rasterizer_pipeline_mode() const
+{
+    return rasterizer_mode;
+}
+
+void RenderEngine::set_rasterizer_parallel_thread_count(int threads)
+{
+    int clamped = std::max(1, threads);
+    rasterizer_parallel_threads = clamped;
+    if (rasterizer_render) {
+        rasterizer_render->set_parallel_thread_count(clamped);
+    }
+}
+
+int RenderEngine::get_rasterizer_parallel_thread_count() const
+{
+    if (rasterizer_render) {
+        return rasterizer_render->parallel_thread_count();
+    }
+    return rasterizer_parallel_threads;
 }
 
 // choose render type
@@ -54,8 +94,10 @@ void FrameBuffer::set_pixel(int index, float depth, const Eigen::Vector3f& color
     // spin locks lock
     spin_locks[index].lock();
 
-    depth_buffer[index] = depth;
-    color_buffer[index] = color;
+    if (depth < depth_buffer[index]) {
+        depth_buffer[index] = depth;
+        color_buffer[index] = color;
+    }
 
     // spin locks unlock
     spin_locks[index].unlock();

--- a/src1/render/render_engine.h
+++ b/src1/render/render_engine.h
@@ -39,6 +39,17 @@ enum class RendererType
 /*!
  * \ingroup rendering
  * \~chinese
+ * \brief 光栅化流水线的运行模式。
+ */
+enum class PipelineMode
+{
+    Serial,
+    Parallel
+};
+
+/*!
+ * \ingroup rendering
+ * \~chinese
  * \brief 离线渲染的执行入口
  */
 class RenderEngine
@@ -65,6 +76,30 @@ public:
      * \param type 渲染器类型
      */
     void render(Scene& scene, RendererType type);
+
+    /*!
+     * \~chinese
+     * \brief 设置光栅化流水线的运行模式
+     */
+    void set_rasterizer_pipeline_mode(PipelineMode mode);
+
+    /*!
+     * \~chinese
+     * \brief 获取当前光栅化流水线的运行模式
+     */
+    PipelineMode get_rasterizer_pipeline_mode() const;
+
+    /*!
+     * \~chinese
+     * \brief 设置并行流水线下每个阶段的线程数
+     */
+    void set_rasterizer_parallel_thread_count(int threads);
+
+    /*!
+     * \~chinese
+     * \brief 获取并行流水线下每个阶段的线程数
+     */
+    int get_rasterizer_parallel_thread_count() const;
     /*! \~chinese 渲染结果预览的背景颜色 */
     static Eigen::Vector3f background_color;
 
@@ -72,6 +107,10 @@ public:
     std::unique_ptr<RasterizerRenderer> rasterizer_render;
     /*! \~chinese whitted style渲染器 */
     std::unique_ptr<WhittedRenderer> whitted_render;
+
+private:
+    PipelineMode rasterizer_mode;
+    int          rasterizer_parallel_threads;
 };
 
 /*!
@@ -91,11 +130,31 @@ public:
     /*! \~chinese 光栅化渲染器的渲染调用接口*/
     void render(const Scene& scene);
 
+    /*!
+     * \~chinese
+     * \brief 配置流水线模式。
+     */
+    void set_pipeline_mode(PipelineMode mode);
+
+    /*!
+     * \~chinese
+     * \brief 设置并行模式下的线程数
+     */
+    void set_parallel_thread_count(int count);
+
+    /*!
+     * \~chinese
+     * \brief 获取并行模式下的线程数
+     */
+    int parallel_thread_count() const;
+
     float& width;
     float& height;
     int    n_vertex_threads;
     int    n_rasterizer_threads;
     int    n_fragment_threads;
+
+    PipelineMode pipeline_mode;
 
     // initialize vertex processor
     VertexProcessor vertex_processor;

--- a/src1/ui/toolbar.cpp
+++ b/src1/ui/toolbar.cpp
@@ -348,7 +348,8 @@ void Toolbar::model_mode(Scene& scene)
     }
 }
 
-const char* renderer_names[] = {"Rasterizer Renderer", "Whitted-Style Ray-Tracer"};
+const char* renderer_names[]    = {"Rasterizer Renderer", "Whitted-Style Ray-Tracer"};
+const char* pipeline_mode_names[] = {"Serial Pipeline", "Parallel Pipeline"};
 
 void Toolbar::render_mode(Scene& scene)
 {
@@ -373,8 +374,22 @@ void Toolbar::render_mode(Scene& scene)
         default: break;
         }
         if (current_renderer == RendererType::RASTERIZER) {
-            ImGui::SetNextItemWidth(0.5f * ImGui::CalcItemWidth());
-            ImGui::InputInt("Number of Threads", &render_engine.n_threads);
+            int pipeline_mode_index =
+                render_engine.get_rasterizer_pipeline_mode() == PipelineMode::Serial ? 0 : 1;
+            if (ImGui::Combo("Pipeline Mode", &pipeline_mode_index, pipeline_mode_names, 2)) {
+                PipelineMode selected_mode =
+                    pipeline_mode_index == 0 ? PipelineMode::Serial : PipelineMode::Parallel;
+                render_engine.set_rasterizer_pipeline_mode(selected_mode);
+            }
+
+            if (pipeline_mode_index == 1) {
+                int parallel_threads = render_engine.get_rasterizer_parallel_thread_count();
+                ImGui::SetNextItemWidth(0.5f * ImGui::CalcItemWidth());
+                if (ImGui::InputInt("Number of Threads", &parallel_threads)) {
+                    render_engine.set_rasterizer_parallel_thread_count(parallel_threads);
+                    parallel_threads = render_engine.get_rasterizer_parallel_thread_count();
+                }
+            }
         }
         if (current_renderer == RendererType::WHITTED_STYLE) {
             ImGui::Checkbox("Use BVH for Acceleration", &render_engine.whitted_render->use_bvh);


### PR DESCRIPTION
## Summary
- restructure the rasterizer renderer so vertex work is fanned out in parallel and triangles are scheduled through an atomic index with fragment batches flowing through a shared queue
- batch triangle rasterization results to cut synchronization overhead and log render time with high precision
- guard frame-buffer writes with a locked depth test to avoid the black output seen in debug builds
- make the pipeline completion flags atomic and update the synchronization waits to consume them safely so debug builds render correctly

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_b_68d7a901e4dc833397caac040027f432